### PR TITLE
created Map component

### DIFF
--- a/step-capstone/public/index.html
+++ b/step-capstone/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <link rel="stylesheet" href="../src/styles.css">
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
@@ -23,7 +24,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
-    <title>React App</title>
+    <title>ZED</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/step-capstone/src/Components/Map.js
+++ b/step-capstone/src/Components/Map.js
@@ -1,0 +1,42 @@
+import React, { createRef } from 'react'
+
+/**
+ * Props:
+ * zoom : 13 - higher the number, the more zoomed the map is on center
+ * center: {lat:0.0, lng:0.0} - coordinates for center of map
+ */
+
+
+class Map extends React.Component {
+  
+  componentDidMount() {
+    const loadGoogleMapScript = document.createElement('script');
+    loadGoogleMapScript.src =
+     'https://maps.googleapis.com/maps/api/js?key=AIzaSyAoxC_RWciy_EVsxVImCWk09xFhWf6AwgY&libraries=place';
+    
+    window.document.body.appendChild(loadGoogleMapScript);
+
+    loadGoogleMapScript.addEventListener('load', () => {
+      this.googleMap = this.createMap();
+    });
+  }
+
+  googleMapRef = createRef();
+  createMap() {
+    new window.google.maps.Map(this.googleMapRef.current, {
+      zoom: this.props.zoom,
+      center: this.props.center,
+    })
+  }
+
+  render() {
+    return(
+      <div
+        id = 'map'
+        ref = {this.googleMapRef}
+      />
+    )
+  }
+}
+
+export default Map

--- a/step-capstone/src/styles/App.css
+++ b/step-capstone/src/styles/App.css
@@ -1,0 +1,9 @@
+.app {
+  height: 100%;
+  width: 100%;
+}
+
+#map {
+  height: 100%;
+  width: 100%;
+}

--- a/step-capstone/src/styles/index.css
+++ b/step-capstone/src/styles/index.css
@@ -1,1 +1,4 @@
-
+html, body, #root {
+  height: 100%;
+  width: 100%;
+}


### PR DESCRIPTION
- added styling componets to make app and map be full screen 

- map.js : created following https://engineering.universe.com/building-a-google-map-in-react-b103b4ee97f1 
componentDidMount runs when the component is created by its parent (trip). it adds the google-maps script to the page so that calls to Maps Api work. it also adds a listener to see if the page is loading, and calls createMap on that. 
createMap() makes a call to the Api to create a Map with some passed in props as configuration (zoom and center)
render returns a div containing the map using a ref from createmap()