### PR TITLE
Hotel interval fix + Fix bug involving multiple events within an hour timespan

### DIFF
--- a/step-capstone/src/components/Finalized.js
+++ b/step-capstone/src/components/Finalized.js
@@ -17,7 +17,6 @@ export default function Finalized(props) {
 
     return (
         <div>
-            {console.log("rerender ", displayDate)}
             <TimeLine
                 list = {props.list}    
                 onRemoveItem={props.onRemoveItem}

--- a/step-capstone/src/components/TimeLine.js
+++ b/step-capstone/src/components/TimeLine.js
@@ -144,7 +144,7 @@ export default function TimeLine(props) {
 
   var displayItems = (date2Items.has(displayDate.toDateString())) ? date2Items.get(displayDate.toDateString()) : [];
   var nextItemIndex = 0;
-  console.log("display items length: ", displayItems.length)
+
   for (var i = 0; i < 24; i++) {
     if (nextItemIndex < displayItems.length) {
       var nextItem = displayItems[nextItemIndex];


### PR DESCRIPTION
- Hotel checkin and checkout renders as two separate 30 minute time blocks on their respective days
- Fixed bug that didn't allow more than 1 travel object to be rendered within a one hour time interval (for example, wouldn't allow an event from 1:00-1:15 and 1:30-1:50) and caused following events to not get rendered