### PR TITLE
Added Suggestion bar

### DIFF
--- a/step-capstone/src/components/Suggestions/SuggestionBar.js
+++ b/step-capstone/src/components/Suggestions/SuggestionBar.js
@@ -10,7 +10,8 @@ export default class SuggestionBar extends React.Component {
 
     this.state = {
       suggestions: props.suggestions,
-      startIndex: 0
+      startIndex: 0,
+      numOfSuggestionsToDisplay: 3
     }
 
     this.loadPrevious = this.loadPrevious.bind(this);
@@ -30,12 +31,25 @@ export default class SuggestionBar extends React.Component {
 
 
   render() {
+    let suggestionItems = [];
+    for (let i = 0; i < this.state.numOfSuggestionsToDisplay; i++) {
+      suggestionItems.push(
+        <Grid item className="suggestion-item-holder">
+          <SuggestionItem
+            suggestion={this.state.suggestions[this.state.startIndex + i]}
+            context={this.props.context}
+            onAddItem={this.props.onAddItem}
+          />
+        </Grid>
+      );
+    }
+    
     return (
       <div id="suggestion-bar">
         <Grid id="suggestion-grid" container direction="row" wrap="nowrap" justify="center" >
           <Grid item>
             <IconButton
-              className="arrow-buttons" 
+              className="arrow-buttons"
               onClick={this.loadPrevious}
               disabled={(this.state.startIndex === 0) ? true : false}
             >
@@ -44,36 +58,16 @@ export default class SuggestionBar extends React.Component {
           </Grid>
 
           <Grid item container id="displayed-suggestions" direction="row" wrap="nowrap" justify="space-around">
-            <Grid item className="suggestion-item-holder">
-              <SuggestionItem 
-                suggestion={this.state.suggestions[this.state.startIndex]} 
-                context={this.props.context}
-                onAddItem={this.props.onAddItem}
-              />
-            </Grid>
-            <Grid item className="suggestion-item-holder">
-              <SuggestionItem 
-                suggestion={this.state.suggestions[this.state.startIndex + 1]}
-                context={this.props.context}
-                onAddItem={this.props.onAddItem}
-              />
-            </Grid>
-            <Grid item className="suggestion-item-holder">
-              <SuggestionItem 
-                suggestion={this.state.suggestions[this.state.startIndex + 2]} 
-                context={this.props.context}
-                onAddItem={this.props.onAddItem}
-              />
-            </Grid>
+            {suggestionItems}
           </Grid>
 
           <Grid item>
             <IconButton
-              className="arrow-buttons" 
+              className="arrow-buttons"
               onClick={this.loadNext}
               disabled={(this.state.startIndex === this.state.suggestions.length) ? true : false}
             >
-              <ArrowRight/>
+              <ArrowRight />
             </IconButton>
           </Grid>
         </Grid>

--- a/step-capstone/src/components/Suggestions/SuggestionBar.js
+++ b/step-capstone/src/components/Suggestions/SuggestionBar.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Grid, IconButton } from '@material-ui/core'
+import { ArrowLeft, ArrowRight } from '@material-ui/icons'
+import "../../styles/Suggestions.css"
+import SuggestionItem from "./SuggestionItem"
+
+export default class SuggestionBar extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      suggestions: props.suggestions,
+      startIndex: 0
+    }
+
+    this.loadPrevious = this.loadPrevious.bind(this);
+    this.loadNext = this.loadNext.bind(this);
+  }
+
+  loadPrevious() {
+    let newStartIndex = this.state.startIndex - 1;
+    this.setState({ startIndex: newStartIndex })
+  }
+
+  loadNext() {
+    let newStartIndex = this.state.startIndex + 1;
+    this.setState({ startIndex: newStartIndex })
+  }
+
+
+
+  render() {
+    return (
+      <div id="suggestion-bar">
+        <Grid id="suggestion-grid" container direction="row" wrap="nowrap" justify="center" >
+          <Grid item>
+            <IconButton
+              className="arrow-buttons" 
+              onClick={this.loadPrevious}
+              disabled={(this.state.startIndex === 0) ? true : false}
+            >
+              <ArrowLeft />
+            </IconButton>
+          </Grid>
+
+          <Grid item container id="displayed-suggestions" direction="row" wrap="nowrap" justify="space-around">
+            <Grid item className="suggestion-item-holder">
+              <SuggestionItem 
+                suggestion={this.state.suggestions[this.state.startIndex]} 
+                context={this.props.context}
+                onAddItem={this.props.onAddItem}
+              />
+            </Grid>
+            <Grid item className="suggestion-item-holder">
+              <SuggestionItem 
+                suggestion={this.state.suggestions[this.state.startIndex + 1]}
+                context={this.props.context}
+                onAddItem={this.props.onAddItem}
+              />
+            </Grid>
+            <Grid item className="suggestion-item-holder">
+              <SuggestionItem 
+                suggestion={this.state.suggestions[this.state.startIndex + 2]} 
+                context={this.props.context}
+                onAddItem={this.props.onAddItem}
+              />
+            </Grid>
+          </Grid>
+
+          <Grid item>
+            <IconButton
+              className="arrow-buttons" 
+              onClick={this.loadNext}
+              disabled={(this.state.startIndex === this.state.suggestions.length) ? true : false}
+            >
+              <ArrowRight/>
+            </IconButton>
+          </Grid>
+        </Grid>
+      </div>
+    )
+  }
+}

--- a/step-capstone/src/components/Suggestions/SuggestionItem.js
+++ b/step-capstone/src/components/Suggestions/SuggestionItem.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  CardMedia,
+  Grid,
+  Typography
+} from '@material-ui/core'
+import FormPopover from "../TravelObjectForms/FormPopover"
+import "../../styles/Suggestions.css"
+import logo from "../../images/logo.png"
+
+export default function SuggestionItem(props) {
+
+  const [anchorEl, setAnchorEl] = React.useState(null);
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+
+
+  }
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const printDollarSigns = (budget) => {
+    if (budget === undefined) {
+      return "";
+    } else if (budget === 0) {
+      return "Free";
+    } else {
+      let cost = "";
+      for (let i = 0; i < budget; i++) {
+        cost += "$";
+      }
+      return cost;
+    }
+  }
+
+  const suggestionToData = (suggestion) => {
+    return {
+      title: (props.suggestion.place.name === undefined) ? "" : props.suggestion.place.name,
+      placeId: props.suggestion.place_id,
+      finalized: props.context.finalized,
+      startDate: props.context.startDate,
+      endDate: props.context.endDate,
+      location: props.suggestion.place.vicinity,
+      coordinates: {
+        lat: props.suggestion.place.geometry.location.lat(),
+        lng: props.suggestion.place.geometry.location.lng()
+      } ,
+      description :"",
+      type: "event"
+    }
+  }
+
+  const open = Boolean(anchorEl);
+
+  return (
+    <Card className="suggestion-item" >
+      <CardHeader titleTypographyProps={{noWrap:"true"}} title={(props.suggestion.place.name === undefined) ? "" : props.suggestion.place.name} />
+
+      <CardMedia
+        className="suggestion-photo"
+        component="img"
+        image={(props.suggestion.place.photos === undefined) ? logo : props.suggestion.place.photos[0].getUrl()}
+        title="suggestion photo"
+      />
+
+      <CardContent>
+        <Grid container justify="space-between">  
+          <Typography className="suggestion-body" variant="subtitle2" inline gutterBottom align="left">
+            Price: {printDollarSigns(props.suggestion.place.price_level)} 
+          </Typography>
+          <Typography className="suggestion-body" variant="subtitle2" inline gutterBottom align="right">
+            Rating: {(props.suggestion.place.rating === undefined) ? "" : props.suggestion.place.rating}
+          </Typography>
+        </Grid>
+      </CardContent>
+
+      <CardActions>
+        <Button variant="contained" onClick={handleClick}>
+          Add
+          </Button>
+      </CardActions>
+
+
+      <FormPopover
+        data={suggestionToData(props.suggestion)}
+        isNewItem={true}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        onAddItem={props.onAddItem}
+      />
+    </Card>
+  )
+}

--- a/step-capstone/src/components/Suggestions/SuggestionItem.js
+++ b/step-capstone/src/components/Suggestions/SuggestionItem.js
@@ -19,8 +19,6 @@ export default function SuggestionItem(props) {
 
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
-
-
   }
 
   const handleClose = () => {
@@ -77,7 +75,7 @@ export default function SuggestionItem(props) {
             Price: {printDollarSigns(props.suggestion.place.price_level)} 
           </Typography>
           <Typography className="suggestion-body" variant="subtitle2" inline gutterBottom align="right">
-            Rating: {(props.suggestion.place.rating === undefined) ? "" : props.suggestion.place.rating}
+            Rating: {(props.suggestion.place.rating === undefined) ? "" : props.suggestion.place.rating +"/5"}
           </Typography>
         </Grid>
       </CardContent>

--- a/step-capstone/src/components/TravelObjectForms/AddEvent.js
+++ b/step-capstone/src/components/TravelObjectForms/AddEvent.js
@@ -21,8 +21,6 @@ export default function AddEvent(props) {
     const [endDate, setEndDate] = useState(overwriting ? props.data.endDate : props.startDate);
     const [checked, setChecked] = useState(overwriting ? props.data.finalized : false);
     const [title, setTitle] = useState(overwriting ? props.data.title : "");
-    console.log(overwriting? props.data.location :"")
-    console.log(overwriting? props.data.coordinates: "")
     const [location, setLocation] = useState(overwriting ? { address: props.data.location, coordinates: props.data.coordinates } : { address: null, coordinates: null });
     const [description, setDescription] = useState(overwriting ? props.data.description : "");
 

--- a/step-capstone/src/components/TravelObjectForms/AddEvent.js
+++ b/step-capstone/src/components/TravelObjectForms/AddEvent.js
@@ -21,6 +21,8 @@ export default function AddEvent(props) {
     const [endDate, setEndDate] = useState(overwriting ? props.data.endDate : props.startDate);
     const [checked, setChecked] = useState(overwriting ? props.data.finalized : false);
     const [title, setTitle] = useState(overwriting ? props.data.title : "");
+    console.log(overwriting? props.data.location :"")
+    console.log(overwriting? props.data.coordinates: "")
     const [location, setLocation] = useState(overwriting ? { address: props.data.location, coordinates: props.data.coordinates } : { address: null, coordinates: null });
     const [description, setDescription] = useState(overwriting ? props.data.description : "");
 

--- a/step-capstone/src/components/TravelObjectForms/AddItemButton.js
+++ b/step-capstone/src/components/TravelObjectForms/AddItemButton.js
@@ -23,6 +23,7 @@ export default function AddItemButton(props) {
             </Fab>
             <FormPopover
                 data={undefined}
+                isNewItem = {true}
                 startDate={props.startDate}
                 open={open}
                 anchorEl={anchorEl}

--- a/step-capstone/src/components/TravelObjectForms/FormPopover.js
+++ b/step-capstone/src/components/TravelObjectForms/FormPopover.js
@@ -18,6 +18,7 @@ export default function FormPopver(props) {
                     onEditItem={props.onEditItem}
                     onRemoveItem={props.onRemoveItem}
                     data={props.data}
+                    isNewItem={props.isNewItem}
                     startDate={props.startDate}
                 />
             </Popover>

--- a/step-capstone/src/components/TravelObjectForms/ItemForm.js
+++ b/step-capstone/src/components/TravelObjectForms/ItemForm.js
@@ -19,7 +19,7 @@ export default class ItemForm extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            isNewItem: props.data === undefined,
+            isNewItem: props.isNewItem,
             value: 0,
             data: props.data,
             isValidated: false
@@ -148,6 +148,7 @@ export default class ItemForm extends React.Component {
     // renders tab if user presses add button to create a new item
     // otherwise only the form should show for editing
     renderTab() {
+      console.log(this.state.isNewItem);
         if (this.state.isNewItem) {
             return (
                 <Paper>

--- a/step-capstone/src/components/TravelObjectForms/ItemForm.js
+++ b/step-capstone/src/components/TravelObjectForms/ItemForm.js
@@ -148,7 +148,6 @@ export default class ItemForm extends React.Component {
     // renders tab if user presses add button to create a new item
     // otherwise only the form should show for editing
     renderTab() {
-      console.log(this.state.isNewItem);
         if (this.state.isNewItem) {
             return (
                 <Paper>

--- a/step-capstone/src/components/TravelObjects/TravelObject.js
+++ b/step-capstone/src/components/TravelObjects/TravelObject.js
@@ -42,6 +42,7 @@ export default function TravelObject(props) {
             </div>
             <FormPopover
                     data={props.data}
+                    isNewItem={false}
                     open={open}
                     anchorEl={anchorEl}
                     onClose={handleClose}

--- a/step-capstone/src/styles/Suggestions.css
+++ b/step-capstone/src/styles/Suggestions.css
@@ -1,0 +1,55 @@
+#suggestion-bar{
+  background-color: white;
+  width: calc(100vw - 610px); 
+  height: 30vh; 
+  left: 305px;
+  bottom: 0%;
+  position: fixed;
+  z-index: 2;
+  pointer-events: auto;
+}
+#suggestion-grid{
+  height:90%;
+  width:100%;
+  position: absolute;
+  top:5%;
+  bottom:5%;
+}
+#displayed-suggestions{
+  height:100%;
+  width: 80%;
+  /* box-sizing:border-box; */
+}
+.suggestion-item-holder{
+  width:25%;
+  height:100%;
+  background-color: #fafafa;
+}
+.suggestion-photo{
+  width: 75%;
+  height: 40%;
+}
+.suggestion-item{
+  width: 100%;
+  height:100%;
+  text-align: center;
+}
+.suggestion-item .MuiCardHeader-root {
+  height: 5%;
+}
+.suggestion-item .MuiCardHeader-content {
+  flex: 1 1 auto;
+  width: 100%;
+}
+.suggestion-item .MuiCardActions-root {
+  justify-content: center;
+  height: 10%;
+}
+.arrow-buttons {
+  position: absolute;
+  top:50%;
+  transform: translate(0%,-50%);
+}
+#suggestion-grid .MuiSvgIcon-root{
+  font-size: 5rem;
+}


### PR DESCRIPTION
- Switched ItemPopover from using props.data==undefined to determine whether this was an edit or an add to using props.isNewItem: also changed FormPopover, TravelObject, and AddItemButton to pass in the new prop. 

- SuggestionBar.js: The overall bar that will display users suggestions. Contains two arrow buttons for next and previous which change a startindex for the displayed SuggestionItems, which get their data from the inputted suggestions array using that startindex.

- SuggestionItem.js: each suggestion item is a materialUI Card component which contains a header (the name of the place), an image from the place.photos (supplied by Google for most places, displays our logo otherwise). Also displays the Price using the $$ system and the Rating from 0 to 5. Finally, contains an Add button that launches the FormPopover and preloads it with the data from the suggestion. 

![image](https://user-images.githubusercontent.com/46660903/87819922-19d16380-c83b-11ea-8722-0ebb395ad326.png)


