### PR TITLE
Suggestion popup

### DIFF
--- a/step-capstone/src/components/Pages/Trip.js
+++ b/step-capstone/src/components/Pages/Trip.js
@@ -175,6 +175,7 @@ export default class Trip extends React.Component {
         })
     }
 
+    // Triggered when a time slot is selected in timeline
     handleSelectTimeslot(timeRange, coordinates, radius) {
         this.setState({
             selectedTimeslot: {
@@ -185,6 +186,7 @@ export default class Trip extends React.Component {
         })
     }
 
+    // only allows rendering of suggestion bar once map is set
     renderSuggestionBar() {
         if (this.state.map) {
             return (

--- a/step-capstone/src/components/Pages/Trip.js
+++ b/step-capstone/src/components/Pages/Trip.js
@@ -2,12 +2,13 @@ import React from 'react';
 import Finalized from '../Sidebars/Finalized';
 import Unfinalized from '../Sidebars/Unfinalized';
 import AddItemButton from '../TravelObjectForms/AddItemButton'
-import { Grid, Box } from '@material-ui/core'
+import { Grid, Box} from '@material-ui/core'
 import '../../styles/Trip.css'
 import { FirebaseContext } from '../Firebase';
 import MapComponent from "../Utilities/Map"
 import { handleSuggestions } from "../../scripts/Suggestions"
 import GetSuggestionButton from '../Utilities/GetSuggestionButton';
+import SuggestionPopup from "../Utilities/SuggestionPopup"
 
 const config = {
     userCategories: ["bakery"],
@@ -35,7 +36,8 @@ export default class Trip extends React.Component {
             map: null,
             service: null,
             queryResults: null,
-            palceIds: new Set()
+            palceIds: new Set(),
+            showSuggestions: false
         }
 
         this.handleRemoveItem = this.handleRemoveItem.bind(this);
@@ -45,6 +47,7 @@ export default class Trip extends React.Component {
         this.handleSelectedObject = this.handleSelectedObject.bind(this);
         this.handleChangeDisplayDate = this.handleChangeDisplayDate.bind(this);
         this.setMap = this.setMap.bind(this);
+        this.toggleSuggestionBar = this.toggleSuggestionBar.bind(this);
     }
 
     componentDidMount() {
@@ -169,6 +172,10 @@ export default class Trip extends React.Component {
         }
     }
 
+    toggleSuggestionBar() {
+        this.setState({ showSuggestions: !this.state.showSuggestions })
+    }
+
     async getActivitySuggestions(config) {
         /**
          * param: 
@@ -247,9 +254,16 @@ export default class Trip extends React.Component {
                         />
                     </Grid>
                 </Grid>
+                <Grid item>
+                    <SuggestionPopup
+                        show={this.state.showSuggestions}
+                    />
+                </Grid>
                 <Grid id="button-group">
                     <Box mb={3}>
-                        <GetSuggestionButton />
+                        <GetSuggestionButton
+                            onClick={this.toggleSuggestionBar}
+                        />
                     </Box>
                     <Box>
                         <AddItemButton

--- a/step-capstone/src/components/Pages/Trip.js
+++ b/step-capstone/src/components/Pages/Trip.js
@@ -82,7 +82,9 @@ export default class Trip extends React.Component {
         this.context.deleteTravelObject(this.state.reference, data)
             .then(() => {
                 var placeIdCopy = new Set(this.state.placeIds);
-                placeIdCopy = placeIdCopy.delete(data.placeId);
+                if (data.type !== "flight") {
+                    placeIdCopy = placeIdCopy.delete(data.placeId);
+                }
                 this.setState({
                     items: this.state.items.filter((item) => item.id !== data.id),
                     placeIds: placeIdCopy
@@ -100,8 +102,10 @@ export default class Trip extends React.Component {
         let newPlaceIds = new Set(this.state.placeIds);
         this.state.items.forEach((item) => {
             if (item.id === data.id) {
-                newPlaceIds.delete(item.placeId);
-                newPlaceIds.add(data.placeId);
+                if (data.type !== "flight") {
+                    newPlaceIds.delete(item.placeId);
+                    newPlaceIds.add(data.placeId);
+                }
                 itemToChange = item;
                 newItems.push(data);
             } else {
@@ -125,7 +129,9 @@ export default class Trip extends React.Component {
     handleAddItem(data) {
         // Add to database here
         var newPlaceIds = new Set(this.state.placeIds);
-        newPlaceIds.add(data.placeId);
+        if (data.type !== "flight") {
+            newPlaceIds.add(data.placeId);
+        }
 
         data.id = Date.now();
         this.context.addTravelObject(this.state.reference, data)

--- a/step-capstone/src/components/Pages/Trip.js
+++ b/step-capstone/src/components/Pages/Trip.js
@@ -197,7 +197,7 @@ export default class Trip extends React.Component {
                         userPref={this.state.tripSetting.userPref}
                         coordinates={this.state.selectedTimeslot ? this.state.selectedTimeslot.coordinates : this.state.tripSetting.destination.coordinates}
                         items={this.state.placeIds}
-                        timeRange= {this.state.selectedTimeslot ? this.state.selectedTimeslot.timeRange : [new Date(2020, 7, 15, 2, 0), new Date(2020, 7, 15, 20, 0)]}
+                        timeRange= {this.state.selectedTimeslot ? this.state.selectedTimeslot.timeRange : [this.state.today.date, this.state.today.date]}
                         radius={this.state.selectedTimeslot ? this.state.selectedTimeslot.radius : this.state.tripSetting.userPref.radius }
                         onClose={this.toggleSuggestionBar}
                     />

--- a/step-capstone/src/components/Pages/Trip.js
+++ b/step-capstone/src/components/Pages/Trip.js
@@ -199,6 +199,7 @@ export default class Trip extends React.Component {
                         items={this.state.placeIds}
                         timeRange= {this.state.selectedTimeslot ? this.state.selectedTimeslot.timeRange : [new Date(2020, 7, 15, 2, 0), new Date(2020, 7, 15, 20, 0)]}
                         radius={this.state.selectedTimeslot ? this.state.selectedTimeslot.radius : this.state.tripSetting.userPref.radius }
+                        onClose={this.toggleSuggestionBar}
                     />
                 </Grid>
             )

--- a/step-capstone/src/components/Pages/Trip.js
+++ b/step-capstone/src/components/Pages/Trip.js
@@ -2,11 +2,12 @@ import React from 'react';
 import Finalized from '../Sidebars/Finalized';
 import Unfinalized from '../Sidebars/Unfinalized';
 import AddItemButton from '../TravelObjectForms/AddItemButton'
-import { Grid } from '@material-ui/core'
+import { Grid, Box } from '@material-ui/core'
 import '../../styles/Trip.css'
 import { FirebaseContext } from '../Firebase';
 import MapComponent from "../Utilities/Map"
 import { handleSuggestions } from "../../scripts/Suggestions"
+import GetSuggestionButton from '../Utilities/GetSuggestionButton';
 
 const config = {
     userCategories: ["bakery"],
@@ -228,11 +229,16 @@ export default class Trip extends React.Component {
                         />
                     </Grid>
                 </Grid>
-                <Grid id="add-button-component">
-                    <AddItemButton
-                        startDate={this.state.tripSetting.startDate}
-                        onAddItem={this.handleAddItem}
-                    />
+                <Grid id="button-group">
+                    <Box mb={3}>
+                        <GetSuggestionButton />
+                    </Box>
+                    <Box>
+                        <AddItemButton
+                            startDate={this.state.tripSetting.startDate}
+                            onAddItem={this.handleAddItem}
+                        />
+                    </Box>
                 </Grid>
             </div>
         );

--- a/step-capstone/src/components/Pages/Trip.js
+++ b/step-capstone/src/components/Pages/Trip.js
@@ -6,7 +6,6 @@ import { Grid, Box } from '@material-ui/core'
 import '../../styles/Trip.css'
 import { FirebaseContext } from '../Firebase';
 import MapComponent from "../Utilities/Map"
-import { handleSuggestions } from "../../scripts/Suggestions"
 import GetSuggestionButton from '../Utilities/GetSuggestionButton';
 import SuggestionPopup from "../Utilities/SuggestionPopup"
 
@@ -66,7 +65,6 @@ export default class Trip extends React.Component {
                     travelObjectList.push(travelObject)
                     placeIds.add(travelObject.placeId);
                 });
-                console.log(placeIds)
                 this.setState({ items: travelObjectList, placeIds: placeIds });
             })
             .catch(error => {

--- a/step-capstone/src/components/TravelObjectForms/AddItemButton.js
+++ b/step-capstone/src/components/TravelObjectForms/AddItemButton.js
@@ -18,7 +18,7 @@ export default function AddItemButton(props) {
     const open = Boolean(anchorEl);
     return (
         <div>
-            <Fab aria-label="add" onClick={handleClick}>
+            <Fab color="primary" aria-label="add" onClick={handleClick}>
                 <AddIcon />
             </Fab>
             <FormPopover
@@ -40,5 +40,4 @@ export default function AddItemButton(props) {
             />
         </div>
     )
-
 }

--- a/step-capstone/src/components/TripForms/TripSettingFormPopover.js
+++ b/step-capstone/src/components/TripForms/TripSettingFormPopover.js
@@ -129,7 +129,7 @@ function EditTripSetting(props) {
         <div >
             <Grid container direction="column">
                 <Grid>
-                    <Typography variant={"h4"} gutterBottom>New Trip</Typography>
+                    <Typography variant={"h4"} gutterBottom>Trip Settings</Typography>
                 </Grid>
                 <Grid item container direction="row" justify="space-between">
                     <TextField

--- a/step-capstone/src/components/TripForms/TripSettingFormPopover.js
+++ b/step-capstone/src/components/TripForms/TripSettingFormPopover.js
@@ -16,6 +16,7 @@ import {
 } from '@material-ui/pickers';
 import LocationAutocompleteInput from "../Utilities/LocationAutocompleteInput"
 import PreferenceForm from "../Utilities/PreferenceForm"
+import "../../styles/TripSetting.css"
 
 export default class TripSettingFormPopover extends React.Component {
     constructor(props) {
@@ -52,8 +53,8 @@ export default class TripSettingFormPopover extends React.Component {
 
     render() {
         return (
-            <Card>
-                <Box width={600}>
+            <Card id="setting-container">
+                <Box>
                     <CardContent>
                         <EditTripSetting
                             tripSetting={this.props.tripSetting}

--- a/step-capstone/src/components/TripForms/TripSettingPopover.js
+++ b/step-capstone/src/components/TripForms/TripSettingPopover.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Backdrop, Button, makeStyles, Popover } from '@material-ui/core';
+import { Backdrop, Button, makeStyles, Popover, Modal } from '@material-ui/core';
 import TripSettingFormPopover from './TripSettingFormPopover';
 import AddIcon from '@material-ui/icons/Add';
+import "../../styles/TripSetting.css"
 
 const useStyles = makeStyles((theme) => ({
   backdrop: {
@@ -42,27 +43,28 @@ export default function TripSettingPopover(props) {
       /> : null}
 
       <Backdrop className={classes.backdrop} open={openBackDrop}></Backdrop>
-      <Popover
+      <Modal
         open={open}
-        anchorEl={anchorEl}
+        // anchorEl={anchorEl}
         onClose={handleClose}
-        anchorReference="anchorPosition"
-        anchorPosition={{ top: 200, left: 450 }}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'left',
-        }}
+        // anchorReference="anchorPosition"
+        // anchorPosition={{ top: 200, left: 450 }}
+        // anchorOrigin={{
+        //   vertical: 'bottom',
+        //   horizontal: 'left',
+        // }}
+        // transformOrigin={{
+        //   vertical: 'top',
+        //   horizontal: 'left',
+        // }}
+        style={{alignItems: "center", justifyContent: "center", display: "flex"}}
       >
         <TripSettingFormPopover
           onClose={handleClose}
           tripSetting={props.tripSetting}
           onEditTripSetting={props.onEditTripSetting}
         />
-      </Popover>
+      </Modal>
     </div>
   );
 }

--- a/step-capstone/src/components/TripForms/TripSettingPopover.js
+++ b/step-capstone/src/components/TripForms/TripSettingPopover.js
@@ -45,18 +45,7 @@ export default function TripSettingPopover(props) {
       <Backdrop className={classes.backdrop} open={openBackDrop}></Backdrop>
       <Modal
         open={open}
-        // anchorEl={anchorEl}
         onClose={handleClose}
-        // anchorReference="anchorPosition"
-        // anchorPosition={{ top: 200, left: 450 }}
-        // anchorOrigin={{
-        //   vertical: 'bottom',
-        //   horizontal: 'left',
-        // }}
-        // transformOrigin={{
-        //   vertical: 'top',
-        //   horizontal: 'left',
-        // }}
         style={{alignItems: "center", justifyContent: "center", display: "flex"}}
       >
         <TripSettingFormPopover

--- a/step-capstone/src/components/Utilities/GetSuggestionButton.js
+++ b/step-capstone/src/components/Utilities/GetSuggestionButton.js
@@ -6,7 +6,7 @@ import EmojiObjectsIcon from '@material-ui/icons/EmojiObjects';
 export default function GetSuggestionButton(props) {
 
     const handleClick = (event) => {
-        console.log("Getting suggestions")
+        props.onClick();
     }
 
     return (

--- a/step-capstone/src/components/Utilities/GetSuggestionButton.js
+++ b/step-capstone/src/components/Utilities/GetSuggestionButton.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Fab } from '@material-ui/core'
+import EmojiObjectsIcon from '@material-ui/icons/EmojiObjects';
+
+
+export default function GetSuggestionButton(props) {
+
+    const handleClick = (event) => {
+        console.log("Getting suggestions")
+    }
+
+    return (
+        <div>
+            <Fab color="secondary" aria-label="suggestion" onClick={handleClick}>
+                <EmojiObjectsIcon />
+            </Fab>
+        </div>
+    )
+}

--- a/step-capstone/src/components/Utilities/PreferenceForm.js
+++ b/step-capstone/src/components/Utilities/PreferenceForm.js
@@ -102,7 +102,7 @@ export default class PreferenceForm extends React.Component {
                                 <FormControl component="fieldset">
                                     <FormLabel component="legend">Activity Preferences</FormLabel>
                                     <Grid container direction="row">
-                                        <Grid item direction="column">
+                                        <Grid item>
                                             <FormGroup>
                                                 <FormControlLabel
                                                     control={
@@ -139,7 +139,7 @@ export default class PreferenceForm extends React.Component {
                                                 />
                                             </FormGroup>
                                         </Grid>
-                                        <Grid item direction="column">
+                                        <Grid item>
                                             <FormGroup>
                                                 <FormControlLabel
                                                     control={
@@ -176,7 +176,7 @@ export default class PreferenceForm extends React.Component {
                                                 />
                                             </FormGroup>
                                         </Grid>
-                                        <Grid item direction="column">
+                                        <Grid item >
                                             <FormGroup>
                                                 <FormControlLabel
                                                     control={

--- a/step-capstone/src/components/Utilities/SuggestionPopup.js
+++ b/step-capstone/src/components/Utilities/SuggestionPopup.js
@@ -136,7 +136,7 @@ export default class SuggestionPopup extends React.Component {
     render() {
         return (
             <Slide direction="up" in={this.props.show} mountOnEnter mountonexit="true">
-                <Paper elevation={3} id="suggestion-component">
+                <Paper elevation={10} id="suggestion-component">
                     <Grid container direction="row">
                         <Grid item>
                             <Box

--- a/step-capstone/src/components/Utilities/SuggestionPopup.js
+++ b/step-capstone/src/components/Utilities/SuggestionPopup.js
@@ -15,15 +15,6 @@ import "../../styles/SuggestionPopup.css"
 import PreferenceForm from "./PreferenceForm"
 import { handleSuggestions } from "../../scripts/Suggestions"
 
-const config = {
-    userCategories: ["sightseeing"],
-    userBudget: 4,
-    radius: "10000",
-    timeRange: [new Date(2020, 7, 15, 2, 0), new Date(2020, 7, 15, 20, 0)],
-    coordinates: { lat: 36.1699, lng: -115.1398 },
-    items: new Set([])
-}
-
 export default class SuggestionPopup extends React.Component {
     constructor(props) {
         super(props);
@@ -51,7 +42,6 @@ export default class SuggestionPopup extends React.Component {
 
     componentDidUpdate(prevProps) {
         if (!prevProps.show && this.props.show) {
-            console.log("Updating")
             this.getSuggestions();
         }
     }
@@ -67,7 +57,6 @@ export default class SuggestionPopup extends React.Component {
         this.setState({ suggestionsLoaded: false });
         this.getActivitySuggestions(this.getConfig("activities")).then(activities => {
             this.getFoodSuggestions(this.getConfig("food")).then(foods => {
-                console.log("Finished loading")
                 if (this.state.radius) {
                     var updatedPref = this.state.userPref;
                     updatedPref.radius = this.state.radius;
@@ -120,7 +109,6 @@ export default class SuggestionPopup extends React.Component {
 
     renderSuggestions() {
         if (!this.state.suggestionsLoaded) {
-            console.log("loading...");
             return (
                 <Grid container justify="center" align-items="center">
                     <Box mt={10}>

--- a/step-capstone/src/components/Utilities/SuggestionPopup.js
+++ b/step-capstone/src/components/Utilities/SuggestionPopup.js
@@ -35,11 +35,7 @@ export default class SuggestionPopup extends React.Component {
         this.renderSuggestions = this.renderSuggestions.bind(this);
         this.getSuggestions = this.getSuggestions.bind(this);
     }
-
-    componentDidMount() {
-        // this.getSuggestions();
-    }
-
+    
     componentDidUpdate(prevProps) {
         if (!prevProps.show && this.props.show) {
             this.getSuggestions();

--- a/step-capstone/src/components/Utilities/SuggestionPopup.js
+++ b/step-capstone/src/components/Utilities/SuggestionPopup.js
@@ -1,10 +1,19 @@
 import React from "react";
-import { Slide, Paper, Tabs, Tab, Grid, Box, Button } from "@material-ui/core"
+import {
+    Slide,
+    Paper,
+    Tabs,
+    Tab,
+    Grid,
+    Box,
+    Button,
+    CircularProgress,
+    IconButton
+} from "@material-ui/core"
+import CloseIcon from '@material-ui/icons/Close';
 import "../../styles/SuggestionPopup.css"
 import PreferenceForm from "./PreferenceForm"
 import { handleSuggestions } from "../../scripts/Suggestions"
-import { render } from "react-dom";
-import { roundToNearestMinutesWithOptions } from "date-fns/fp";
 
 const config = {
     userCategories: ["sightseeing"],
@@ -34,15 +43,15 @@ export default class SuggestionPopup extends React.Component {
         this.handleToggleTab = this.handleToggleTab.bind(this);
         this.renderSuggestions = this.renderSuggestions.bind(this);
         this.getSuggestions = this.getSuggestions.bind(this);
-        this.getSuggestions = this.getSuggestions.bind(this);
     }
 
     componentDidMount() {
-        this.getSuggestions();
+        // this.getSuggestions();
     }
 
     componentDidUpdate(prevProps) {
         if (!prevProps.show && this.props.show) {
+            console.log("Updating")
             this.getSuggestions();
         }
     }
@@ -58,6 +67,7 @@ export default class SuggestionPopup extends React.Component {
         this.setState({ suggestionsLoaded: false });
         this.getActivitySuggestions(this.getConfig("activities")).then(activities => {
             this.getFoodSuggestions(this.getConfig("food")).then(foods => {
+                console.log("Finished loading")
                 if (this.state.radius) {
                     var updatedPref = this.state.userPref;
                     updatedPref.radius = this.state.radius;
@@ -111,12 +121,19 @@ export default class SuggestionPopup extends React.Component {
     renderSuggestions() {
         if (!this.state.suggestionsLoaded) {
             console.log("loading...");
+            return (
+                <Grid container justify="center" align-items="center">
+                    <Box mt={10}>
+                        <CircularProgress color="secondary" />
+                    </Box>
+                </Grid>
+            )
         }
         // TODO: Suggestion component
         if (this.state.tabPos === 0) {
-            console.log(this.state.activitySuggestions)
+            console.log("Activities: ", this.state.activitySuggestions)
         } else {
-            console.log(this.state.foodSuggestions)
+            console.log("Food: ", this.state.foodSuggestions)
         }
     }
 
@@ -154,8 +171,8 @@ export default class SuggestionPopup extends React.Component {
                                 </Box>
                             </Box>
                         </Grid>
-                        <Grid item>
-                            <Box width={700}>
+                        <Grid item xs>
+                            <Box width={"100%"} height={"100%"}>
                                 <Tabs
                                     variant="fullWidth"
                                     indicatorColor="secondary"
@@ -165,7 +182,17 @@ export default class SuggestionPopup extends React.Component {
                                     <Tab label="Activities" />
                                     <Tab label="Food" />
                                 </Tabs>
+                                {this.renderSuggestions()}
                             </Box>
+                        </Grid>
+                        <Grid item>
+                            <IconButton
+                                color="secondary"
+                                aria-label="close"
+                                onClick={this.props.onClose}
+                            >
+                                <CloseIcon />
+                            </IconButton>
                         </Grid>
                     </Grid>
                 </Paper>

--- a/step-capstone/src/components/Utilities/SuggestionPopup.js
+++ b/step-capstone/src/components/Utilities/SuggestionPopup.js
@@ -35,7 +35,7 @@ export default class SuggestionPopup extends React.Component {
         this.renderSuggestions = this.renderSuggestions.bind(this);
         this.getSuggestions = this.getSuggestions.bind(this);
     }
-    
+
     componentDidUpdate(prevProps) {
         if (!prevProps.show && this.props.show) {
             this.getSuggestions();
@@ -113,7 +113,7 @@ export default class SuggestionPopup extends React.Component {
                 </Grid>
             )
         }
-        // TODO: Suggestion component
+        // TODO: Pass data into Zachs suggestion component.
         if (this.state.tabPos === 0) {
             console.log("Activities: ", this.state.activitySuggestions)
         } else {

--- a/step-capstone/src/components/Utilities/SuggestionPopup.js
+++ b/step-capstone/src/components/Utilities/SuggestionPopup.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { Slide, Card, Typography } from "@material-ui/core"
+import "../../styles/SuggestionPopup.css"
+
+export default function SuggestionPopup(props) {
+
+    return (
+        <Slide direction="up" in={props.show} mountOnEnter mountOnExit>
+            <Card elevation={3} id="suggestion-component">
+              
+            </Card>
+        </Slide>
+    )
+}

--- a/step-capstone/src/scripts/Suggestions.js
+++ b/step-capstone/src/scripts/Suggestions.js
@@ -84,7 +84,6 @@ const query = (service, config, type) => {
     return new Promise(res => {
         let types = type === "food" ? config.userCategories : ["tourist_attraction", "natural_feature"]
         let places = queryPlaces(config.coordinates, config.radius, service, types)
-
         places.then(results => {
             results = filterAlreadySelected(results, config.items);
             if (types[0] === "tourist_attraction") {

--- a/step-capstone/src/styles/SuggestionPopup.css
+++ b/step-capstone/src/styles/SuggestionPopup.css
@@ -1,5 +1,5 @@
 #suggestion-component {
-    z-index: 5;
+    z-index: 7;
     position: fixed;
     bottom: 0;
     left: 0;
@@ -9,4 +9,12 @@
 
 .scroll {
     overflow-y: auto;
+}
+
+.test {
+    background-color: aquamarine;
+}
+
+.fullWidth {
+    width: 100%;
 }

--- a/step-capstone/src/styles/SuggestionPopup.css
+++ b/step-capstone/src/styles/SuggestionPopup.css
@@ -6,3 +6,7 @@
     width: 100%;
     height: 350px;
 }
+
+.scroll {
+    overflow-y: auto;
+}

--- a/step-capstone/src/styles/SuggestionPopup.css
+++ b/step-capstone/src/styles/SuggestionPopup.css
@@ -11,10 +11,6 @@
     overflow-y: auto;
 }
 
-.test {
-    background-color: aquamarine;
-}
-
 .fullWidth {
     width: 100%;
 }

--- a/step-capstone/src/styles/SuggestionPopup.css
+++ b/step-capstone/src/styles/SuggestionPopup.css
@@ -1,0 +1,8 @@
+#suggestion-component {
+    z-index: 5;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 350px;
+}

--- a/step-capstone/src/styles/Trip.css
+++ b/step-capstone/src/styles/Trip.css
@@ -53,7 +53,7 @@
     pointer-events: none;
 }
 
-#add-button-component {
+#button-group {
     z-index: 5;
     position: fixed;
     bottom: 0;

--- a/step-capstone/src/styles/Trip.css
+++ b/step-capstone/src/styles/Trip.css
@@ -54,7 +54,7 @@
 }
 
 #button-group {
-    z-index: 5;
+    z-index: 6;
     position: fixed;
     bottom: 0;
     right: 0;

--- a/step-capstone/src/styles/TripSetting.css
+++ b/step-capstone/src/styles/TripSetting.css
@@ -1,0 +1,3 @@
+#setting-container {
+    width: 600px;
+}


### PR DESCRIPTION
- Idea button that triggers popup for suggestions --> animated from bottom
- By default loads saved user preferences (from trip settings) into preference bar on side, but users can adjust and filter as they wish without changing their default preferences
- Display user preference bar on side for users to filter through suggestions on the spot (scrollable)
- Tab controller to display either activity suggestions or food suggestions --> will render Zach's component below the tab bar passing in whichever array is needed.
- Loading animation when querying places from API
- Retrieves suggestions based on user preferences (either passed in or specified) and ensures everything is well formatted to be passed into Zach's component
- Changed trip setting form from popover to modal in order to properly render in center of screen
- Trip functions are setup to be passed down to timeline to retrieve proper parameters for retrieving suggestions (radius, coordinates, time-range) and should be able to integrate with Dan's component through that.

<img width="1789" alt="Screen Shot 2020-07-17 at 5 20 49 PM" src="https://user-images.githubusercontent.com/14339580/87831571-ddf5c880-c851-11ea-8b29-d4318ac5a9a9.png">
<img width="205" alt="Screen Shot 2020-07-17 at 5 21 04 PM" src="https://user-images.githubusercontent.com/14339580/87831581-e77f3080-c851-11ea-9779-2c9c00102389.png">
<img width="1776" alt="Screen Shot 2020-07-17 at 5 23 15 PM" src="https://user-images.githubusercontent.com/14339580/87831696-34fb9d80-c852-11ea-9f14-6d6e2f0e274c.png">


