### PR TITLE
Food time preferences

### DIFF
--- a/step-capstone/package.json
+++ b/step-capstone/package.json
@@ -15,6 +15,7 @@
     "firebase": "^7.16.1",
     "firebaseui": "^4.6.0",
     "lodash": "^4.17.19",
+    "moment": "^2.27.0",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.1",
     "react-dom": "^16.13.1",

--- a/step-capstone/src/components/Pages/Trip.js
+++ b/step-capstone/src/components/Pages/Trip.js
@@ -10,6 +10,7 @@ import GetSuggestionButton from '../Suggestions/GetSuggestionButton';
 import SuggestionPopup from "../Suggestions/SuggestionPopup"
 import { getOptimalRoute, createSchedule } from "../../scripts/Optimization"
 import _ from "lodash"
+import FoodTimeForm from '../Utilities/FoodTimeForm';
 
 // TODO: Implement code with form
 // getOptimalRoute(_.cloneDeep(this.state.items), { coordinates: { lat: 51.501167, lng: -0.119185 } }, { coordinates: { lat: 51.501167, lng: -0.119185 } })
@@ -77,7 +78,7 @@ export default class Trip extends React.Component {
                         endDate: trip.startDate.toDate(),
                         destination: trip.destination,
                         description: trip.description,
-                        userPref: trip.userPref
+                        userPref: trip.userPref,
                     }
                 })
 

--- a/step-capstone/src/components/TripForms/AddTrip.js
+++ b/step-capstone/src/components/TripForms/AddTrip.js
@@ -30,9 +30,9 @@ export default function AddTrip(props) {
             budget: 2,
             radius: 10,
             activityPreferences: [],
-            foodPreferences: []
-        },
-        foodTimeRanges: [3600000, 3600000, 3600000]
+            foodPreferences: [],
+            foodTimeRanges: [3600000, 3600000, 3600000]
+        }
     }
     const handleEditTrip = (newTrip) => {
         newTrip.travelObjects = [];

--- a/step-capstone/src/components/TripForms/AddTrip.js
+++ b/step-capstone/src/components/TripForms/AddTrip.js
@@ -31,7 +31,8 @@ export default function AddTrip(props) {
             radius: 10,
             activityPreferences: [],
             foodPreferences: []
-        }
+        },
+        foodTimeRanges: [3600000, 3600000, 3600000]
     }
     const handleEditTrip = (newTrip) => {
         newTrip.travelObjects = [];

--- a/step-capstone/src/components/TripForms/AddTrip.js
+++ b/step-capstone/src/components/TripForms/AddTrip.js
@@ -4,6 +4,7 @@ import {
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import TripSettingPopover from './TripSettingPopover';
+import moment from "moment"
 
 const useStyles = makeStyles({
     root: {
@@ -31,7 +32,7 @@ export default function AddTrip(props) {
             radius: 10,
             activityPreferences: [],
             foodPreferences: [],
-            foodTimeRanges: [3600000, 3600000, 3600000]
+            foodTimeRanges: [moment.duration(1, 'hour').asMilliseconds(), moment.duration(1, 'hour').asMilliseconds(), moment.duration(1, 'hour').asMilliseconds()]
         }
     }
     const handleEditTrip = (newTrip) => {

--- a/step-capstone/src/components/TripForms/TripSettingFormPopover.js
+++ b/step-capstone/src/components/TripForms/TripSettingFormPopover.js
@@ -18,6 +18,7 @@ import LocationAutocompleteInput from "../Utilities/LocationAutocompleteInput"
 import PreferenceForm from "../Utilities/PreferenceForm"
 import "../../styles/TripSetting.css"
 import { fetchPhoto } from "../../scripts/HelperFunctions"
+import FoodTimeForm from "../Utilities/FoodTimeForm"
 
 export default class TripSettingFormPopover extends React.Component {
     constructor(props) {
@@ -53,6 +54,7 @@ export default class TripSettingFormPopover extends React.Component {
     }
 
     render() {
+
         return (
             <Card id="setting-container">
                 <Box>
@@ -85,6 +87,7 @@ function EditTripSetting(props) {
     const [endDate, setEndDate] = useState(props.tripSetting.endDate);
     const [description, setDescription] = useState(props.tripSetting.description);
     const [userPref, setUserPref] = useState(props.tripSetting.userPref);
+    const [foodTimeRanges, setFoodTimeRanges] = useState(props.tripSetting.foodTimeRanges);
 
     const handleTitleChange = (event) => {
         setTitle(event.target.value);
@@ -122,6 +125,10 @@ function EditTripSetting(props) {
         setUserPref(pref);
     }
 
+    const handleFoodTimeRangesChange = (timeranges) => {
+        setFoodTimeRanges(timeranges);
+    }
+
     useEffect(() => {
         let newMap = new window.google.maps.Map(window.document.getElementById("map"))
         setMap(newMap);
@@ -136,14 +143,14 @@ function EditTripSetting(props) {
             startDate: startDate,
             endDate: endDate,
             description: description,
-            userPref: userPref
+            userPref: userPref,
+            foodTimeRanges: foodTimeRanges
         })
         // notifies form if necessary inputs are present
         props.onValidation(!(!destination || (title === "")))
-    }, [destination, startDate, endDate, description, userPref, photoUrl])
-
+    }, [destination, startDate, endDate, description, userPref, photoUrl, foodTimeRanges])
     return (
-        <div >
+        <div>
             <div id="map"></div>
             <Grid container direction="column">
                 <Grid>
@@ -201,6 +208,7 @@ function EditTripSetting(props) {
                 />
             </Grid>
             <PreferenceForm pref={userPref} onChange={handleUserPrefChange} />
+            <FoodTimeForm foodTimeRanges={foodTimeRanges} onChange={handleFoodTimeRangesChange} />
         </div>
     )
 }

--- a/step-capstone/src/components/TripForms/TripSettingFormPopover.js
+++ b/step-capstone/src/components/TripForms/TripSettingFormPopover.js
@@ -18,7 +18,6 @@ import LocationAutocompleteInput from "../Utilities/LocationAutocompleteInput"
 import PreferenceForm from "../Utilities/PreferenceForm"
 import "../../styles/TripSetting.css"
 import { fetchPhoto } from "../../scripts/HelperFunctions"
-import FoodTimeForm from "../Utilities/FoodTimeForm"
 
 export default class TripSettingFormPopover extends React.Component {
     constructor(props) {
@@ -54,7 +53,6 @@ export default class TripSettingFormPopover extends React.Component {
     }
 
     render() {
-
         return (
             <Card id="setting-container">
                 <Box>
@@ -87,7 +85,6 @@ function EditTripSetting(props) {
     const [endDate, setEndDate] = useState(props.tripSetting.endDate);
     const [description, setDescription] = useState(props.tripSetting.description);
     const [userPref, setUserPref] = useState(props.tripSetting.userPref);
-    const [foodTimeRanges, setFoodTimeRanges] = useState(props.tripSetting.foodTimeRanges);
 
     const handleTitleChange = (event) => {
         setTitle(event.target.value);
@@ -125,10 +122,6 @@ function EditTripSetting(props) {
         setUserPref(pref);
     }
 
-    const handleFoodTimeRangesChange = (timeranges) => {
-        setFoodTimeRanges(timeranges);
-    }
-
     useEffect(() => {
         let newMap = new window.google.maps.Map(window.document.getElementById("map"))
         setMap(newMap);
@@ -144,11 +137,11 @@ function EditTripSetting(props) {
             endDate: endDate,
             description: description,
             userPref: userPref,
-            foodTimeRanges: foodTimeRanges
         })
         // notifies form if necessary inputs are present
         props.onValidation(!(!destination || (title === "")))
-    }, [destination, startDate, endDate, description, userPref, photoUrl, foodTimeRanges])
+    }, [destination, startDate, endDate, description, userPref, photoUrl])
+
     return (
         <div>
             <div id="map"></div>
@@ -208,7 +201,6 @@ function EditTripSetting(props) {
                 />
             </Grid>
             <PreferenceForm pref={userPref} onChange={handleUserPrefChange} />
-            <FoodTimeForm foodTimeRanges={foodTimeRanges} onChange={handleFoodTimeRangesChange} />
         </div>
     )
 }

--- a/step-capstone/src/components/Utilities/FoodTimeForm.js
+++ b/step-capstone/src/components/Utilities/FoodTimeForm.js
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from "react"
+import {
+    Grid,
+    Box,
+    TextField,
+    InputAdornment,
+    Input,
+    FormControl,
+    FormHelperText,
+    Slider,
+    Typography
+} from "@material-ui/core"
+const MILLISECONDS_PER_MIN = 60000;
+
+export default function FoodTimeForm(props) {
+    const [breakfastDuration, setBreakfastDuration] = useState(props.foodTimeRanges[0] / MILLISECONDS_PER_MIN);
+    const [lunchDuration, setLunchDuration] = useState(props.foodTimeRanges[1] / MILLISECONDS_PER_MIN);
+    const [dinnerDuration, setDinnerDuration] = useState(props.foodTimeRanges[2] / MILLISECONDS_PER_MIN);
+
+    const handleBreakfastDurationChange = (event, hours) => {
+        setBreakfastDuration(hours);
+    }
+
+    const handleLunchDurationChange = (event, hours) => {
+        setLunchDuration(hours);
+    }
+
+    const handleDinnerDurationChange = (event, hours) => {
+        setDinnerDuration(hours);
+    }
+
+    useEffect(() => {
+        props.onChange({
+            foodTimeRanges: [
+                breakfastDuration * MILLISECONDS_PER_MIN, 
+                lunchDuration * MILLISECONDS_PER_MIN,
+                dinnerDuration * MILLISECONDS_PER_MIN
+            ]
+        })
+    }, [breakfastDuration, lunchDuration, dinnerDuration])
+
+    const marks = [
+        {
+            value: 30,
+            label: "30 min"
+        },
+        {
+            value: 60,
+            label: "60 min"
+        },
+        {
+            value: 90,
+            label: "90 min"
+        },
+        {
+            value: 120,
+            label: "120 min"
+        }
+    ]
+
+    return (
+        <Grid container direction="column">
+            <Grid item>
+                <Box my={3} mr={3}>
+                    <Typography id="discrete-slider-custom" gutterBottom>Breakfast Duration</Typography>
+                    <Slider
+                        value={breakfastDuration}
+                        step={10}
+                        valueLabelDisplay="auto"
+                        marks={marks}
+                        min={20}
+                        max={120}
+                        onChange={handleBreakfastDurationChange}
+                    />
+                </Box>
+            </Grid>
+            <Grid item>
+                <Box my={1} mr={3}>
+                    <Typography id="discrete-slider-custom" gutterBottom>Lunch Duration</Typography>
+                    <Slider
+                        value={lunchDuration}
+                        step={10}
+                        valueLabelDisplay="auto"
+                        marks={marks}
+                        min={20}
+                        max={120}
+                        onChange={handleLunchDurationChange}
+                    />
+                </Box>
+            </Grid>
+            <Grid item>
+                <Box my={1} mr={3}>
+                    <Typography id="discrete-slider-custom" gutterBottom>Dinner Duration</Typography>
+                    <Slider
+                        value={dinnerDuration}
+                        step={10}
+                        valueLabelDisplay="auto"
+                        marks={marks}
+                        min={20}
+                        max={120}
+                        onChange={handleDinnerDurationChange}
+                    />
+                </Box>
+            </Grid>
+        </Grid>
+    )
+}

--- a/step-capstone/src/components/Utilities/FoodTimeForm.js
+++ b/step-capstone/src/components/Utilities/FoodTimeForm.js
@@ -5,30 +5,30 @@ import {
     Slider,
     Typography
 } from "@material-ui/core"
+import moment from "moment"
 
 export default function FoodTimeForm(props) {
-    const MILLISECONDS_PER_MIN = 60000;
-    const [breakfastDuration, setBreakfastDuration] = useState(Math.floor(props.foodTimeRanges[0] / MILLISECONDS_PER_MIN));
-    const [lunchDuration, setLunchDuration] = useState(Math.floor(props.foodTimeRanges[1] / MILLISECONDS_PER_MIN));
-    const [dinnerDuration, setDinnerDuration] = useState(Math.floor(props.foodTimeRanges[2] / MILLISECONDS_PER_MIN));
+    const [breakfastDuration, setBreakfastDuration] = useState(moment.duration(props.foodTimeRanges[0]).asMinutes());
+    const [lunchDuration, setLunchDuration] = useState(moment.duration(props.foodTimeRanges[1]).asMinutes());
+    const [dinnerDuration, setDinnerDuration] = useState(moment.duration(props.foodTimeRanges[2]).asMinutes());
 
-    const handleBreakfastDurationChange = (event, hours) => {
-        setBreakfastDuration(hours);
+    const handleBreakfastDurationChange = (event, mins) => {
+        setBreakfastDuration(mins);
     }
 
-    const handleLunchDurationChange = (event, hours) => {
-        setLunchDuration(hours);
+    const handleLunchDurationChange = (event, mins) => {
+        setLunchDuration(mins);
     }
 
-    const handleDinnerDurationChange = (event, hours) => {
-        setDinnerDuration(hours);
+    const handleDinnerDurationChange = (event, mins) => {
+        setDinnerDuration(mins);
     }
 
     useEffect(() => {
         props.onChange([
-            breakfastDuration * MILLISECONDS_PER_MIN,
-            lunchDuration * MILLISECONDS_PER_MIN,
-            dinnerDuration * MILLISECONDS_PER_MIN
+            moment.duration(breakfastDuration, "minutes").asMilliseconds(),
+            moment.duration(lunchDuration, "minutes").asMilliseconds(),
+            moment.duration(dinnerDuration, "minutes").asMilliseconds(),
         ])
     }, [breakfastDuration, lunchDuration, dinnerDuration])
 

--- a/step-capstone/src/components/Utilities/FoodTimeForm.js
+++ b/step-capstone/src/components/Utilities/FoodTimeForm.js
@@ -2,20 +2,15 @@ import React, { useEffect, useState } from "react"
 import {
     Grid,
     Box,
-    TextField,
-    InputAdornment,
-    Input,
-    FormControl,
-    FormHelperText,
     Slider,
     Typography
 } from "@material-ui/core"
-const MILLISECONDS_PER_MIN = 60000;
 
 export default function FoodTimeForm(props) {
-    const [breakfastDuration, setBreakfastDuration] = useState(props.foodTimeRanges[0] / MILLISECONDS_PER_MIN);
-    const [lunchDuration, setLunchDuration] = useState(props.foodTimeRanges[1] / MILLISECONDS_PER_MIN);
-    const [dinnerDuration, setDinnerDuration] = useState(props.foodTimeRanges[2] / MILLISECONDS_PER_MIN);
+    const MILLISECONDS_PER_MIN = 60000;
+    const [breakfastDuration, setBreakfastDuration] = useState(Math.floor(props.foodTimeRanges[0] / MILLISECONDS_PER_MIN));
+    const [lunchDuration, setLunchDuration] = useState(Math.floor(props.foodTimeRanges[1] / MILLISECONDS_PER_MIN));
+    const [dinnerDuration, setDinnerDuration] = useState(Math.floor(props.foodTimeRanges[2] / MILLISECONDS_PER_MIN));
 
     const handleBreakfastDurationChange = (event, hours) => {
         setBreakfastDuration(hours);
@@ -30,13 +25,11 @@ export default function FoodTimeForm(props) {
     }
 
     useEffect(() => {
-        props.onChange({
-            foodTimeRanges: [
-                breakfastDuration * MILLISECONDS_PER_MIN,
-                lunchDuration * MILLISECONDS_PER_MIN,
-                dinnerDuration * MILLISECONDS_PER_MIN
-            ]
-        })
+        props.onChange([
+            breakfastDuration * MILLISECONDS_PER_MIN,
+            lunchDuration * MILLISECONDS_PER_MIN,
+            dinnerDuration * MILLISECONDS_PER_MIN
+        ])
     }, [breakfastDuration, lunchDuration, dinnerDuration])
 
     const marks = [
@@ -87,7 +80,7 @@ export default function FoodTimeForm(props) {
                         step={10}
                         valueLabelDisplay="auto"
                         marks={marks}
-                        min={20}
+                        min={0}
                         max={120}
                         onChange={handleLunchDurationChange}
                     />
@@ -101,7 +94,7 @@ export default function FoodTimeForm(props) {
                         step={10}
                         valueLabelDisplay="auto"
                         marks={marks}
-                        min={20}
+                        min={0}
                         max={120}
                         onChange={handleDinnerDurationChange}
                     />

--- a/step-capstone/src/components/Utilities/FoodTimeForm.js
+++ b/step-capstone/src/components/Utilities/FoodTimeForm.js
@@ -32,7 +32,7 @@ export default function FoodTimeForm(props) {
     useEffect(() => {
         props.onChange({
             foodTimeRanges: [
-                breakfastDuration * MILLISECONDS_PER_MIN, 
+                breakfastDuration * MILLISECONDS_PER_MIN,
                 lunchDuration * MILLISECONDS_PER_MIN,
                 dinnerDuration * MILLISECONDS_PER_MIN
             ]
@@ -61,6 +61,11 @@ export default function FoodTimeForm(props) {
     return (
         <Grid container direction="column">
             <Grid item>
+                <Box mt={2}>
+                    <Typography variant="subtitle2" gutterBottom>Enter a duration for each meal and we'll be sure to leave space in your schedule.</Typography>
+                </Box>
+            </Grid>
+            <Grid item>
                 <Box my={3} mr={3}>
                     <Typography id="discrete-slider-custom" gutterBottom>Breakfast Duration</Typography>
                     <Slider
@@ -68,7 +73,7 @@ export default function FoodTimeForm(props) {
                         step={10}
                         valueLabelDisplay="auto"
                         marks={marks}
-                        min={20}
+                        min={0}
                         max={120}
                         onChange={handleBreakfastDurationChange}
                     />

--- a/step-capstone/src/components/Utilities/PreferenceForm.js
+++ b/step-capstone/src/components/Utilities/PreferenceForm.js
@@ -13,6 +13,7 @@ import {
     FormGroup,
     Checkbox
 } from "@material-ui/core"
+import FoodTimeForm from "../Utilities/FoodTimeForm"
 
 export default class PreferenceForm extends React.Component {
     constructor(props) {
@@ -21,7 +22,8 @@ export default class PreferenceForm extends React.Component {
             budget: this.props.pref.budget,
             radius: this.props.pref.radius,
             activityPreferences: this.props.pref.activityPreferences,
-            foodPreferences: this.props.pref.foodPreferences
+            foodPreferences: this.props.pref.foodPreferences,
+            foodTimeRanges: this.props.pref.foodTimeRanges
         }
     }
 
@@ -45,6 +47,10 @@ export default class PreferenceForm extends React.Component {
 
     handleFoodPreferenceCheck = (event) => {
         this.togglePreferenceHelper("foodPreferences", event.target.name)
+    }
+
+    handleFoodTimeRangesChange = (timeranges) => {
+        this.setState({ foodTimeRanges: timeranges });
     }
 
     togglePreferenceHelper = (listName, pref) => {
@@ -250,6 +256,7 @@ export default class PreferenceForm extends React.Component {
                                 </Grid>
                             </FormControl>
                         </Grid>
+                        <FoodTimeForm foodTimeRanges={this.state.foodTimeRanges} onChange={this.handleFoodTimeRangesChange} />
                     </Grid>
                 </Grid>
             </Box>

--- a/step-capstone/src/styles/TripSetting.css
+++ b/step-capstone/src/styles/TripSetting.css
@@ -1,3 +1,5 @@
 #setting-container {
     width: 600px;
+    height: 750px;
+    overflow-y: scroll;
 }

--- a/step-capstone/yarn.lock
+++ b/step-capstone/yarn.lock
@@ -7745,6 +7745,11 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+moment@^2.27.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
+  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
- FoodTimeForm: new child component of preference form with three sliders to select preferred duration for breakfast, lunch, and dinner to aid with our optimization algorithm. Sliders are in minutes.
- Updated trip settings to include foodTimeRanges attribute, which is an array of length 3 each containing the number of milliseconds of the respective duration (0: breakfast, 1: lunch, 2: dinner).
- Default everything to 1 hour
- Resized setting popover form height and added scroll.

<img width="883" alt="Screen Shot 2020-07-24 at 11 45 30 AM" src="https://user-images.githubusercontent.com/14339580/88409614-2dcd1600-cda3-11ea-83e3-f4e5d70797c5.png">
