### PR TITLE
Prevent date conflict

### DIFF
--- a/step-capstone/src/components/Pages/Trip.js
+++ b/step-capstone/src/components/Pages/Trip.js
@@ -207,6 +207,7 @@ export default class Trip extends React.Component {
                         onClose={this.toggleSuggestionBar}
                         finalized={this.state.selectedTimeslot !== null}
                         onAddItem={this.handleAddItem}
+                        travelObjects={this.state.items}
                     />
                 </Grid>
             )
@@ -246,6 +247,7 @@ export default class Trip extends React.Component {
                             setTodaysEvents={this.handleChangeDisplayDate}
                             onClickTimeslot={this.handleSelectTimeslot}
                             onOpenSuggestions={this.toggleSuggestionBar}
+                            travelObjects={this.state.items}
                         />
                     </Grid>
                     <Grid item id="unfinalized-component">
@@ -257,6 +259,7 @@ export default class Trip extends React.Component {
                             tripSetting={this.state.tripSetting}
                             onEditTripSetting={this.handleEditTripSetting}
                             onClickObject={this.handleSelectedObject}
+                            travelObjects={this.state.items}
                         />
                     </Grid>
                 </Grid>
@@ -271,6 +274,7 @@ export default class Trip extends React.Component {
                         <AddItemButton
                             startDate={this.state.tripSetting.startDate}
                             onAddItem={this.handleAddItem}
+                            travelObjects={this.state.items}
                         />
                     </Box>
                 </Grid>

--- a/step-capstone/src/components/Sidebars/Finalized.js
+++ b/step-capstone/src/components/Sidebars/Finalized.js
@@ -29,6 +29,7 @@ export default function Finalized(props) {
                 onClickTimeslot={props.onClickTimeslot}
                 onOpenSuggestions={props.onOpenSuggestions}
                 startDate={props.startDate}
+                travelObjects={props.travelObjects}
             />
         </div>
 

--- a/step-capstone/src/components/Sidebars/InsertObjectPopover.js
+++ b/step-capstone/src/components/Sidebars/InsertObjectPopover.js
@@ -84,6 +84,7 @@ export default function InsertObjectPopover(props) {
               startDate={props.startDate}
               onAddItem={props.onAddItem}
               onClose={handleClose}
+              travelObjects={props.travelObjects}
             />
           </Box>
           <Box p={5}>

--- a/step-capstone/src/components/Sidebars/OneHourInterval.js
+++ b/step-capstone/src/components/Sidebars/OneHourInterval.js
@@ -90,6 +90,7 @@ export default function OneHourInterval(props) {
             position: "absolute",
             zIndex: props.zIndex.toString(),
           }}
+          travelObjects={props.travelObjects}
         />
       );
 
@@ -130,6 +131,7 @@ export default function OneHourInterval(props) {
         onOpenSuggestions={props.onOpenSuggestions}
         onClose={handleClose}
         startDate={props.startDate}
+        travelObjects={props.travelObjects}
       />
     </div>
   );

--- a/step-capstone/src/components/Sidebars/TimeLine.js
+++ b/step-capstone/src/components/Sidebars/TimeLine.js
@@ -113,6 +113,7 @@ export default class TimeLine extends React.Component {
                 onClickTimeslot={this.props.onClickTimeslot}
                 onOpenSuggestions={this.props.onOpenSuggestions}
                 startDate={this.props.startDate}
+                travelObjects={this.props.travelObjects}
               />
             );
           } else {
@@ -151,6 +152,7 @@ export default class TimeLine extends React.Component {
                 onClickTimeslot={this.props.onClickTimeslot}
                 onOpenSuggestions={this.props.onOpenSuggestions}
                 startDate={this.props.startDate}
+                travelObjects={this.props.travelObjects}
               />
             );
           }
@@ -169,6 +171,7 @@ export default class TimeLine extends React.Component {
               onClickTimeslot={this.props.onClickTimeslot}
               onOpenSuggestions={this.props.onOpenSuggestions}
               startDate={this.props.startDate}
+              travelObjects={this.props.travelObjects}
             />
           );
         }

--- a/step-capstone/src/components/Sidebars/Unfinalized.js
+++ b/step-capstone/src/components/Sidebars/Unfinalized.js
@@ -83,6 +83,7 @@ export default class Unfinalized extends React.Component {
                 onAddItem={this.props.onAddItem}
                 styleConfig={{ position: "relative", top: "1px" }}
                 onClickObject={this.props.onClickObject}
+                travelObjects={this.props.travelObjects}
               />
             })
           }

--- a/step-capstone/src/components/Suggestions/SuggestionBar.js
+++ b/step-capstone/src/components/Suggestions/SuggestionBar.js
@@ -59,6 +59,7 @@ export default class SuggestionBar extends React.Component {
             suggestion={this.state.suggestions[this.state.startIndex + i]}
             context={this.props.context}
             onAddItem={this.props.onAddItem}
+            travelObjects={this.props.travelObjects}
           />
         </Grid>
       );

--- a/step-capstone/src/components/Suggestions/SuggestionItem.js
+++ b/step-capstone/src/components/Suggestions/SuggestionItem.js
@@ -106,6 +106,7 @@ export default function SuggestionItem(props) {
           horizontal: 'left',
         }}
         onAddItem={props.onAddItem}
+        travelObjects={props.travelObjects}
       />
     </Card>
   )

--- a/step-capstone/src/components/Suggestions/SuggestionPopup.js
+++ b/step-capstone/src/components/Suggestions/SuggestionPopup.js
@@ -123,6 +123,7 @@ export default class SuggestionPopup extends React.Component {
                     endDate: this.props.timeRange[1]
                 }}
                 onAddItem={this.props.onAddItem}
+                travelObjects={this.props.travelObjects}
             />
         )
     }

--- a/step-capstone/src/components/TravelObjectForms/AddEvent.js
+++ b/step-capstone/src/components/TravelObjectForms/AddEvent.js
@@ -13,9 +13,7 @@ import {
 } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
 import LocationAutocompleteInput from "../Utilities/LocationAutocompleteInput";
-import {isValid, hasTimeConflict} from '../../scripts/HelperFunctions';
-
-const travelObjects = [{startDate:new Date(2020,6,24,8), endDate: new Date(2020,6,24,12)}]
+import { isValid, hasTimeConflict } from '../../scripts/HelperFunctions';
 
 export default function AddEvent(props) {
   let overwriting = props.data !== undefined;
@@ -33,15 +31,15 @@ export default function AddEvent(props) {
   const [location, setLocation] = useState(
     overwriting
       ? {
-          address: props.data.location,
-          coordinates: props.data.coordinates,
-          placeId: props.data.placeId,
-        }
-      : { 
-          address: "",
-          coordinates: "",
-          placeId: "",
-        }
+        address: props.data.location,
+        coordinates: props.data.coordinates,
+        placeId: props.data.placeId,
+      }
+      : {
+        address: "",
+        coordinates: "",
+        placeId: "",
+      }
   );
   const [description, setDescription] = useState(
     overwriting ? props.data.description : ""
@@ -93,9 +91,9 @@ export default function AddEvent(props) {
     //validating input
     if (title === "") {
       props.onToggleValidation(false);
-    } else if (checked && (location===null||location.address===""||location.address===null)) {
+    } else if (checked && (location === null || location.address === "" || location.address === null)) {
       props.onToggleValidation(false);
-    } else if (!isValid(startDate) || !isValid(endDate)) {
+    } else if (!isValid(startDate) || !isValid(endDate) || (checked && hasTimeConflict(props.data.id, startDate, endDate, props.travelObjects))) {
       props.onToggleValidation(false);
     } else {
       props.onToggleValidation(true);
@@ -136,8 +134,8 @@ export default function AddEvent(props) {
             label={"Start"}
             value={startDate}
             onChange={setStartDate}
-            error={hasTimeConflict(startDate, travelObjects)}
-            helperText={hasTimeConflict(startDate, travelObjects)? "You already have something scheduled for that time" :""}
+            error={checked && hasTimeConflict(props.data.id, startDate, endDate, props.travelObjects)}
+            helperText={checked && hasTimeConflict(props.data.id, startDate, endDate, props.travelObjects) ? "You already have something scheduled for that time" : ""}
           />
         </MuiPickersUtilsProvider>
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
@@ -146,8 +144,8 @@ export default function AddEvent(props) {
             label={"End"}
             value={endDate}
             onChange={setEndDate}
-            error={hasTimeConflict(endDate, travelObjects)}
-            helperText="You already have something scheduled for that time"
+            error={checked && hasTimeConflict(props.data.id, startDate, endDate, props.travelObjects)}
+            helperText={checked && hasTimeConflict(props.data.id, startDate, endDate, props.travelObjects) ? "You already have something scheduled for that time" : ""}
           />
         </MuiPickersUtilsProvider>
       </Grid>
@@ -155,7 +153,7 @@ export default function AddEvent(props) {
         <Box my={1}>
           <LocationAutocompleteInput
             onLocationSelected={handleLocationChange}
-            error={checked && (location===null||location.address===""||location.address===null)}
+            error={checked && (location === null || location.address === "" || location.address === null)}
             text={location ? location.address : ""}
             type="event"
           />

--- a/step-capstone/src/components/TravelObjectForms/AddEvent.js
+++ b/step-capstone/src/components/TravelObjectForms/AddEvent.js
@@ -13,7 +13,9 @@ import {
 } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
 import LocationAutocompleteInput from "../Utilities/LocationAutocompleteInput";
-import {isValid} from '../../scripts/HelperFunctions';
+import {isValid, hasTimeConflict} from '../../scripts/HelperFunctions';
+
+const travelObjects = [{startDate:new Date(2020,6,24,8), endDate: new Date(2020,6,24,12)}]
 
 export default function AddEvent(props) {
   let overwriting = props.data !== undefined;
@@ -134,6 +136,8 @@ export default function AddEvent(props) {
             label={"Start"}
             value={startDate}
             onChange={setStartDate}
+            error={hasTimeConflict(startDate, travelObjects)}
+            helperText={hasTimeConflict(startDate, travelObjects)? "You already have something scheduled for that time" :""}
           />
         </MuiPickersUtilsProvider>
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
@@ -142,6 +146,8 @@ export default function AddEvent(props) {
             label={"End"}
             value={endDate}
             onChange={setEndDate}
+            error={hasTimeConflict(endDate, travelObjects)}
+            helperText="You already have something scheduled for that time"
           />
         </MuiPickersUtilsProvider>
       </Grid>

--- a/step-capstone/src/components/TravelObjectForms/AddFlight.js
+++ b/step-capstone/src/components/TravelObjectForms/AddFlight.js
@@ -13,7 +13,7 @@ import {
 } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
 import LocationAutocompleteInput from "../Utilities/LocationAutocompleteInput";
-import { isValid } from "../../scripts/HelperFunctions";
+import { isValid, hasTimeConflict } from "../../scripts/HelperFunctions";
 
 export default function AddFlight(props) {
   let overwriting = props.data !== undefined;
@@ -102,7 +102,8 @@ export default function AddFlight(props) {
         (departureAirport === null || departureAirport.address === "") ||
         (arrivalAirport === null || arrivalAirport.addresss === "") ||
         !isValid(startDate) ||
-        !isValid(endDate)
+        !isValid(endDate) ||
+        (checked && hasTimeConflict(props.data.id, startDate, endDate, props.travelObjects))
       )
     );
   }, [
@@ -155,6 +156,8 @@ export default function AddFlight(props) {
             label="Departure"
             value={startDate}
             onChange={setStartDate}
+            error={checked && hasTimeConflict(props.data.id, startDate, endDate, props.travelObjects)}
+            helperText={checked && hasTimeConflict(props.data.id, startDate, endDate, props.travelObjects) ? "You already have something scheduled for that time" : ""}
           />
         </MuiPickersUtilsProvider>
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
@@ -163,6 +166,8 @@ export default function AddFlight(props) {
             label="Arrival"
             value={endDate}
             onChange={setEndDate}
+            error={checked && hasTimeConflict(props.data.id, startDate, endDate, props.travelObjects)}
+            helperText={checked && hasTimeConflict(props.data.id, startDate, endDate, props.travelObjects) ? "You already have something scheduled for that time" : ""}
           />
         </MuiPickersUtilsProvider>
       </Grid>

--- a/step-capstone/src/components/TravelObjectForms/AddItemButton.js
+++ b/step-capstone/src/components/TravelObjectForms/AddItemButton.js
@@ -41,6 +41,7 @@ export default function AddItemButton(props) {
                 }}
                 onAddItem={props.onAddItem}
                 onEditItem={props.onEditItem}
+                travelObjects={props.travelObjects}
             />
         </div>
     )

--- a/step-capstone/src/components/TravelObjectForms/FormPopover.js
+++ b/step-capstone/src/components/TravelObjectForms/FormPopover.js
@@ -20,6 +20,7 @@ export default function FormPopver(props) {
                     data={props.data}
                     isNewItem={props.isNewItem}
                     startDate={props.startDate}
+                    travelObjects={props.travelObjects}
                 />
             </Popover>
         </div>

--- a/step-capstone/src/components/TravelObjectForms/ItemForm.js
+++ b/step-capstone/src/components/TravelObjectForms/ItemForm.js
@@ -115,6 +115,7 @@ export default class ItemForm extends React.Component {
           data={this.state.data}
           onToggleValidation={this.handleToggleValidation}
           startDate={this.props.startDate}
+          travelObjects={this.props.travelObjects}
         />
       );
     } else if (
@@ -127,6 +128,7 @@ export default class ItemForm extends React.Component {
           data={this.state.data}
           onToggleValidation={this.handleToggleValidation}
           startDate={this.props.startDate}
+          travelObjects={this.props.travelObjects}
         />
       );
     } else {
@@ -136,6 +138,7 @@ export default class ItemForm extends React.Component {
           data={this.state.data}
           onToggleValidation={this.handleToggleValidation}
           startDate={this.props.startDate}
+          travelObjects={this.props.travelObjects}
         />
       );
     }

--- a/step-capstone/src/components/TravelObjects/TravelObject.js
+++ b/step-capstone/src/components/TravelObjects/TravelObject.js
@@ -60,6 +60,7 @@ export default function TravelObject(props) {
                     onAddItem={props.onAddItem}
                     onEditItem={props.onEditItem}
                     onRemoveItem={props.onRemoveItem}
+                    travelObjects={props.travelObjects}
                 />
         </div>
 

--- a/step-capstone/src/scripts/HelperFunctions.js
+++ b/step-capstone/src/scripts/HelperFunctions.js
@@ -43,8 +43,6 @@ export const fetchPhoto = function (placeId, service) {
 export const hasTimeConflict = (id, startDate, endDate, travelObjects) => {
   var foundConflict = false;
   travelObjects.forEach((travelObject) => {
-    console.log("editing id", id)
-    console.log("travelobj", travelObject.id)
     if(travelObject.finalized && id!==travelObject.id){
       if (overlaps(travelObject.startDate, travelObject.endDate, startDate, endDate)) {
         foundConflict = true;

--- a/step-capstone/src/scripts/HelperFunctions.js
+++ b/step-capstone/src/scripts/HelperFunctions.js
@@ -1,14 +1,14 @@
 
 export const travelObjectStartDateComparator = (travelObjectA, travelObjectB) => {
-    if (travelObjectA.startDate === travelObjectB.startDate) {
-      return 0;
-    }
-    else if (travelObjectA.startDate > travelObjectB.startDate) {
-      return 1;
-    }
-    else {
-      return -1;
-    }
+  if (travelObjectA.startDate === travelObjectB.startDate) {
+    return 0;
+  }
+  else if (travelObjectA.startDate > travelObjectB.startDate) {
+    return 1;
+  }
+  else {
+    return -1;
+  }
 }
 
 /*Given 2 Date objects, return true if they have the same date; return false otherwise */
@@ -22,17 +22,17 @@ export const isValid = function (date) {
   return date.getTime() === date.getTime();
 };
 
-export const fetchPhoto = function(placeId, service) {
+export const fetchPhoto = function (placeId, service) {
   let request = {
     placeId: placeId,
-    fields : ["photos"]
+    fields: ["photos"]
   }
   return new Promise((res) => {
     service.getDetails(
       request, (results, status) => {
         if (status === window.google.maps.places.PlacesServiceStatus.OK) {
           let url = results.photos[0].getUrl();
-          res(url); 
+          res(url);
         }
       }
     )
@@ -40,21 +40,24 @@ export const fetchPhoto = function(placeId, service) {
 }
 
 //returns true if there is a conflict, false otherwise
-export const hasTimeConflict = (date, travelObjects) => {
-  console.log("in time conflict")
-  console.log("date",date)
+export const hasTimeConflict = (id, startDate, endDate, travelObjects) => {
   var foundConflict = false;
   travelObjects.forEach((travelObject) => {
-    console.log("objects",travelObject.startDate)
-    if(contains(travelObject.startDate, travelObject.endDate, date)) {
-      foundConflict = true;
-    } 
+    console.log("editing id", id)
+    console.log("travelobj", travelObject.id)
+    if(travelObject.finalized && id!==travelObject.id){
+      if (overlaps(travelObject.startDate, travelObject.endDate, startDate, endDate)) {
+        foundConflict = true;
+      }
+    }
   });
-  console.log(foundConflict)
   return foundConflict;
 }
 
-export const contains = (startTime, endTime, timePoint) => {
-  // return whether timeRange from startTime to endTime contains timePoint
-  return startTime < timePoint && timePoint < endTime;
+export const overlaps = (startTimeA, endTimeA, startTimeB, endTimeB) => {
+  if ((startTimeA < endTimeB) && (endTimeA > startTimeB)) {
+    return true;
+  } else {
+    return false;
+  }
 }

--- a/step-capstone/src/scripts/HelperFunctions.js
+++ b/step-capstone/src/scripts/HelperFunctions.js
@@ -1,3 +1,4 @@
+
 export const travelObjectStartDateComparator = (travelObjectA, travelObjectB) => {
     if (travelObjectA.startDate === travelObjectB.startDate) {
       return 0;
@@ -38,3 +39,22 @@ export const fetchPhoto = function(placeId, service) {
   })
 }
 
+//returns true if there is a conflict, false otherwise
+export const hasTimeConflict = (date, travelObjects) => {
+  console.log("in time conflict")
+  console.log("date",date)
+  var foundConflict = false;
+  travelObjects.forEach((travelObject) => {
+    console.log("objects",travelObject.startDate)
+    if(contains(travelObject.startDate, travelObject.endDate, date)) {
+      foundConflict = true;
+    } 
+  });
+  console.log(foundConflict)
+  return foundConflict;
+}
+
+export const contains = (startTime, endTime, timePoint) => {
+  // return whether timeRange from startTime to endTime contains timePoint
+  return startTime < timePoint && timePoint < endTime;
+}


### PR DESCRIPTION
- The add and edit item forms now check whether the inputted dates overlap with an existing finalized event or flight. Hotels are ignored. 

- AddEvent and AddFlight now call hasTimeConflict to check with the about to be inputted item has a conflict. It passes in the id (to avoid a time conflict with the same travelObject, its start and end times, and the other travelObjects. 

- HelperFunctions.js has two new functions: hasTimeConflict iterates through the provided travelObjects and, if the object is finalized, and not the same object as the one being checked, calls the overlaps() function which determines if the times overlap. it returns true if there is a conflict

- All the other files have one single change - passing down the travelObjects list to allow the forms to check if there is a conflict. 