### PR TITLE
Change default date

### DIFF
--- a/step-capstone/src/components/Pages/Trip.js
+++ b/step-capstone/src/components/Pages/Trip.js
@@ -269,7 +269,7 @@ export default class Trip extends React.Component {
                     </Box>
                     <Box>
                         <AddItemButton
-                            startDate={this.state.tripSetting.startDate}
+                            startDate={new Date(this.state.today.date)}
                             onAddItem={this.handleAddItem}
                         />
                     </Box>

--- a/step-capstone/src/components/Sidebars/TimeLine.js
+++ b/step-capstone/src/components/Sidebars/TimeLine.js
@@ -66,9 +66,26 @@ export default class TimeLine extends React.Component {
   getIntervals() {
     let intervals = [];
     if (this.props.displayDate !== undefined) {
+      this.startOfDisplayDate = 
       this.date2Items = new Map();
       this.displayItems = [];
       this.emptySlots = [];
+      this.startOfDisplayDate = new Date(
+        this.props.displayDate.getFullYear(),
+        this.props.displayDate.getMonth(),
+        this.props.displayDate.getDate(),
+        0,
+        0,
+        0
+      );
+      this.endOfDisplayDate = new Date(
+        this.props.displayDate.getFullYear(),
+        this.props.displayDate.getMonth(),
+        this.props.displayDate.getDate(),
+        23,
+        59,
+        59
+      );
       this.separateDates();
       this.displayItems = this.date2Items.has(
         this.props.displayDate.toDateString()


### PR DESCRIPTION
- Trip.js: pass in the date the user is currently looking at into add item rather than the start of the trip 

- Timeline.js: added updating of the display start and end dates to fix bug where adding items after start date of trip always used the same start date. 