### PR TITLE
fixed bug where suggestions did not load on day with no items

### DIFF
--- a/step-capstone/src/components/Pages/Trip.js
+++ b/step-capstone/src/components/Pages/Trip.js
@@ -200,7 +200,8 @@ export default class Trip extends React.Component {
                         show={this.state.showSuggestions}
                         service={this.state.service}
                         userPref={this.state.tripSetting.userPref}
-                        coordinates={this.state.selectedTimeslot ? this.state.selectedTimeslot.coordinates : this.state.tripSetting.destination.coordinates}
+                        coordinates={(this.state.selectedTimeslot && this.state.selectedTimeslot.coordinates) ?
+                          this.state.selectedTimeslot.coordinates : this.state.tripSetting.destination.coordinates}
                         items={this.state.placeIds}
                         timeRange= {this.state.selectedTimeslot ? this.state.selectedTimeslot.timeRange : [todayStartTime, todayEndTime]}
                         radius={this.state.tripSetting.userPref.radius }

--- a/step-capstone/src/components/Sidebars/TimeLine.js
+++ b/step-capstone/src/components/Sidebars/TimeLine.js
@@ -66,8 +66,7 @@ export default class TimeLine extends React.Component {
   getIntervals() {
     let intervals = [];
     if (this.props.displayDate !== undefined) {
-      this.startOfDisplayDate = 
-      this.date2Items = new Map();
+      this.startOfDisplayDate = this.date2Items = new Map();
       this.displayItems = [];
       this.emptySlots = [];
       this.startOfDisplayDate = new Date(
@@ -96,13 +95,13 @@ export default class TimeLine extends React.Component {
         this.displayItems,
         this.props.displayDate.toDateString()
       );
-      
+
 
       this.displayItems.sort(travelObjectStartDateComparator);
       this.displayItemsExcludeHotel = this.displayItems.filter((item) => item.type !== "hotel");
-      
+
       this.emptySlots = getEmptySlots(this.startOfDisplayDate, this.endOfDisplayDate, this.displayItemsExcludeHotel)
-    
+
       var nextItemIndex = 0;
       for (var i = 0; i < 24; i++) {
         if (nextItemIndex < this.displayItems.length) {


### PR DESCRIPTION
- previosuly, requesting suggestions on a date without any travelObjects would fail - this was because there were no coordinates being supplied to the request. We now check whether the coordinates are null, and if so, pass in the default coordinates gathered from the location of the user's overall trip. 