### PR TITLE
removed the flight and hotel tabs when adding suggestions

### DIFF
--- a/step-capstone/src/components/Suggestions/SuggestionItem.js
+++ b/step-capstone/src/components/Suggestions/SuggestionItem.js
@@ -107,6 +107,7 @@ export default function SuggestionItem(props) {
         }}
         onAddItem={props.onAddItem}
         travelObjects={props.travelObjects}
+        isFromSuggestions={true}
       />
     </Card>
   )

--- a/step-capstone/src/components/TravelObjectForms/FormPopover.js
+++ b/step-capstone/src/components/TravelObjectForms/FormPopover.js
@@ -21,6 +21,7 @@ export default function FormPopver(props) {
                     isNewItem={props.isNewItem}
                     startDate={props.startDate}
                     travelObjects={props.travelObjects}
+                    isFromSuggestions={props.isFromSuggestions}
                 />
             </Popover>
         </div>

--- a/step-capstone/src/components/TravelObjectForms/ItemForm.js
+++ b/step-capstone/src/components/TravelObjectForms/ItemForm.js
@@ -161,7 +161,7 @@ export default class ItemForm extends React.Component {
   // renders tab if user presses add button to create a new item
   // otherwise only the form should show for editing
   renderTab() {
-    if (this.state.isNewItem) {
+    if (this.state.isNewItem && !this.props.isFromSuggestions) {
       return (
         <Paper>
           <Tabs


### PR DESCRIPTION
- a bug happened when users clicked add on a suggestion, and then tried to navigate to the flight and hotel tabs of the item form - but we dont need these when adding a suggestion, so I removed these tabs from rendering when calling the form from suggestions bar