### PR TITLE
fixed suggestion display on small screens

### DIFF
--- a/step-capstone/src/components/Suggestions/SuggestionBar.js
+++ b/step-capstone/src/components/Suggestions/SuggestionBar.js
@@ -28,6 +28,7 @@ export default class SuggestionBar extends React.Component {
   }
 
   componentDidMount() {
+    this.updateDisplayNum();
     window.addEventListener("resize", this.updateDisplayNum)
   }
 
@@ -67,7 +68,7 @@ export default class SuggestionBar extends React.Component {
 
     return (
       <div id="suggestion-bar">
-        <Grid id="suggestion-grid" container direction="row" justify="center" nowrap>
+        <Grid id="suggestion-grid" container direction="row" justify="center" wrap="nowrap">
           <Grid item>
             <IconButton
               className="arrow-buttons"


### PR DESCRIPTION
- when on smaller screens, the suggestions bar would become unusable as the arrow button to navigate would wrap onto the next line and disappear. 

- Two components of the fix: our function to update the number of items to display only ran on a resize, meaning if user starts with a small window, it would give them the default amount, which was too many. We know calculate on each initial mount as well. 
Also fixed the nowrap syntax of the container holding the suggestions, which now prevents wrapping to the next line. 