### PR TITLE
Refactor HandleClickInTimeLine to handle edge cases & Add Unit Tests

### DIFF
--- a/step-capstone/src/__tests__/SearchForEmptyTimeslot.test.js
+++ b/step-capstone/src/__tests__/SearchForEmptyTimeslot.test.js
@@ -43,6 +43,7 @@ const TIMEPOINT_1746 = new Date("2020-08-07T17:46:00Z");
 
 const TIMEPOINT_1800 = new Date("2020-08-07T18:00:00Z");
 const TIMEPOINT_2245 = new Date("2020-08-07T22:45:00Z");
+const TIMEPOINT_2246 = new Date("2020-08-07T22:46:00Z");
 
 const TIMEPOINT_2300 = new Date("2020-08-07T23:00:00Z");
 const TIMEPOINT_2330 = new Date("2020-08-07T23:30:00Z");
@@ -574,7 +575,52 @@ test("Case 25: Five items, Clickpoint is in the last free timeslot of the day", 
   });
 });
 
-test("Case 26: Five items, clickPoint is in between 3rd and 4th item", () => {
+test("Case 26: Five items, clickPoint is in the 1st free timeslot of the day", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_0100,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      FIVE_ITEMS
+    )
+  ).toStrictEqual({
+    prevTravelObject: null,
+    freeTimeSlot: {startDate: startOfDisplayDate, endDate: TIMEPOINT_0915},
+    nextTravelObject: ITEM_5_0915_TO_1345,
+  });
+});
+
+test("Case 27: Five items, clickPoint is in the 2nd free timeslot of the day", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1400,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      FIVE_ITEMS
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_5_0915_TO_1345,
+    freeTimeSlot: {startDate: TIMEPOINT_1345, endDate: TIMEPOINT_1430},
+    nextTravelObject: ITEM_7_1430_TO_1700,
+  });
+});
+
+test("Case 28: Five items, clickPoint is in the 3rd free timeslot", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1715,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      FIVE_ITEMS
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_7_1430_TO_1700,
+    freeTimeSlot: {startDate: TIMEPOINT_1700, endDate: TIMEPOINT_1730},
+    nextTravelObject: ITEM_9_1730_TO_1745,
+  });
+});
+
+test("Case 29: Five items, clickPoint is in the 4th free timeslot", () => {
   expect(
     handleClickedTimePoint(
       TIMEPOINT_1746,
@@ -589,7 +635,22 @@ test("Case 26: Five items, clickPoint is in between 3rd and 4th item", () => {
   });
 });
 
-test("Case 27: One full day, clickPoint is in the item ", () => {
+test("Case 30: Five items, clickPoint is in the 5th free timeslot", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_2246,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      FIVE_ITEMS
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_10_1800_TO_2245,
+    freeTimeSlot: {startDate: TIMEPOINT_2245, endDate: TIMEPOINT_2300},
+    nextTravelObject: ITEM_11_2300_TO_2330,
+  });
+});
+
+test("Case 31: One full day, clickPoint is in the item ", () => {
   expect(
     handleClickedTimePoint(
       TIMEPOINT_2331,

--- a/step-capstone/src/__tests__/SearchForEmptyTimeslot.test.js
+++ b/step-capstone/src/__tests__/SearchForEmptyTimeslot.test.js
@@ -1,0 +1,605 @@
+import "@testing-library/jest-dom";
+import { handleClickedTimePoint } from "../components/Sidebars/HandleClickedTimePoint";
+// TEST DATA
+const TIMEPOINT_2300_PREVDAY = new Date("2020-08-06T23:00:00Z");
+
+const TIMEPOINT_0000 = new Date("2020-08-07T00:00:00Z");
+const TIMEPOINT_0100 = new Date("2020-08-07T01:00:00Z");
+const TIMEPOINT_0109 = new Date("2020-08-07T01:09:00Z");
+const TIMEPOINT_0115 = new Date("2020-08-07T01:15:00Z");
+
+const TIMEPOINT_0230 = new Date("2020-08-07T02:30:00Z");
+
+const TIMEPOINT_0301 = new Date("2020-08-07T03:01:00Z");
+const TIMEPOINT_0315 = new Date("2020-08-07T03:15:00Z");
+const TIMEPOINT_0330 = new Date("2020-08-07T03:30:00Z");
+
+const TIMEPOINT_0500 = new Date("2020-08-07T05:00:00Z");
+const TIMEPOINT_0515 = new Date("2020-08-07T05:15:00Z");
+
+const TIMEPOINT_0645 = new Date("2020-08-07T06:45:00Z");
+
+const TIMEPOINT_0830 = new Date("2020-08-07T08:30:00Z");
+
+const TIMEPOINT_0915 = new Date("2020-08-07T09:15:00Z");
+const TIMEPOINT_0945 = new Date("2020-08-07T09:45:00Z");
+
+const TIMEPOINT_1000 = new Date("2020-08-07T10:00:00Z");
+
+const TIMEPOINT_1315 = new Date("2020-08-07T13:15:00Z");
+const TIMEPOINT_1330 = new Date("2020-08-07T13:30:00Z");
+const TIMEPOINT_1345 = new Date("2020-08-07T13:45:00Z");
+
+const TIMEPOINT_1400 = new Date("2020-08-07T14:00:00Z");
+const TIMEPOINT_1430 = new Date("2020-08-07T14:30:00Z");
+
+const TIMEPOINT_1659 = new Date("2020-08-07T16:59:00Z");
+const TIMEPOINT_1700 = new Date("2020-08-07T17:00:00Z");
+const TIMEPOINT_1715 = new Date("2020-08-07T17:15:00Z");
+const TIMEPOINT_1718 = new Date("2020-08-07T17:18:00Z");
+const TIMEPOINT_1730 = new Date("2020-08-07T17:30:00Z");
+const TIMEPOINT_1745 = new Date("2020-08-07T17:45:00Z");
+const TIMEPOINT_1746 = new Date("2020-08-07T17:46:00Z");
+
+const TIMEPOINT_1800 = new Date("2020-08-07T18:00:00Z");
+const TIMEPOINT_2245 = new Date("2020-08-07T22:45:00Z");
+
+const TIMEPOINT_2300 = new Date("2020-08-07T23:00:00Z");
+const TIMEPOINT_2330 = new Date("2020-08-07T23:30:00Z");
+const TIMEPOINT_2331 = new Date("2020-08-07T23:31:00Z");
+
+const TIMEPOINT_0100_NEXTDAY = new Date("2020-08-08T01:00:00Z");
+
+const startOfDisplayDate = TIMEPOINT_0000;
+const endOfDisplayDate = new Date("2020-08-07T23:59:59Z");
+
+const ITEM_2300_PREV_DAY_TO_0100 = {
+  id: "random",
+  startDate: TIMEPOINT_2300_PREVDAY,
+  endDate: TIMEPOINT_0100,
+};
+const ITEM_2300_TO_0100_NEXT_DAY = {
+  id: "random",
+  startDate: TIMEPOINT_2300,
+  endDate: TIMEPOINT_0100_NEXTDAY,
+};
+const ITEM_1_0115_TO_0230 = {
+  id: "random",
+  startDate: TIMEPOINT_0115,
+  endDate: TIMEPOINT_0230,
+};
+const ITEM_2_0230_TO_0315 = {
+  id: "random",
+  startDate: TIMEPOINT_0230,
+  endDate: TIMEPOINT_0315,
+};
+const ITEM_3_0330_TO_0500 = {
+  id: "random",
+  startDate: TIMEPOINT_0330,
+  endDate: TIMEPOINT_0500,
+};
+const ITEM_4_0515_TO_0645 = {
+  id: "random",
+  startDate: TIMEPOINT_0515,
+  endDate: TIMEPOINT_0645,
+};
+const ITEM_5_0915_TO_1345 = {
+  id: "random",
+  startDate: TIMEPOINT_0915,
+  endDate: TIMEPOINT_1345,
+};
+const ITEM_6_1345_TO_1400 = {
+  id: "random",
+  startDate: TIMEPOINT_1345,
+  endDate: TIMEPOINT_1400,
+};
+const ITEM_7_1430_TO_1700 = {
+  id: "random",
+  startDate: TIMEPOINT_1430,
+  endDate: TIMEPOINT_1700,
+};
+const ITEM_8_1700_TO_1715 = {
+  id: "random",
+  startDate: TIMEPOINT_1700,
+  endDate: TIMEPOINT_1715,
+};
+const ITEM_9_1730_TO_1745 = {
+  id: "random",
+  startDate: TIMEPOINT_1730,
+  endDate: TIMEPOINT_1745,
+};
+const ITEM_10_1800_TO_2245 = {
+  id: "random",
+  startDate: TIMEPOINT_1800,
+  endDate: TIMEPOINT_2245,
+};
+const ITEM_11_2300_TO_2330 = {
+  id: "random",
+  startDate: TIMEPOINT_2300,
+  endDate: TIMEPOINT_2330,
+};
+const ITEM_12_0000_TO_2359 = {
+  id: "random",
+  startDate: startOfDisplayDate,
+  endDate: endOfDisplayDate,
+};
+
+const EMPTY_DAY = [];
+
+const ONE_ITEM_OVERFLOWS_FROM_PREV_DAY = [ITEM_2300_PREV_DAY_TO_0100];
+const ONE_ITEM_OVERFLOWS_TO_NEXT_DAY = [ITEM_2300_TO_0100_NEXT_DAY];
+const ONE_ITEM_IN_THE_MIDDLE = [ITEM_5_0915_TO_1345];
+
+const TWO_ITEMS_NOT_RELATE_TO_PREV_OR_NEXT_DAY = [
+  ITEM_2_0230_TO_0315,
+  ITEM_8_1700_TO_1715,
+];
+const TWO_ITEMS_ONE_FROM_PREV_ANOTHER_MIDDLE = [
+  ITEM_2300_PREV_DAY_TO_0100,
+  ITEM_5_0915_TO_1345,
+];
+const TWO_ITEMS_ONE_TO_NEXT_DAY = [
+  ITEM_5_0915_TO_1345,
+  ITEM_2300_TO_0100_NEXT_DAY,
+];
+
+const THREE_ITEMS_WITH_2_ITEMS_SAME_EDGE = [
+  ITEM_1_0115_TO_0230,
+  ITEM_2_0230_TO_0315,
+  ITEM_5_0915_TO_1345,
+];
+const THREE_ITEMS_WITH_2_SHORT_ITEMS = [
+  ITEM_8_1700_TO_1715,
+  ITEM_9_1730_TO_1745,
+  ITEM_11_2300_TO_2330,
+];
+const THREE_ITEMS_RELATE_TO_PREV_AND_NEXT_DAY = [
+  ITEM_2300_PREV_DAY_TO_0100,
+  ITEM_3_0330_TO_0500,
+  ITEM_2300_TO_0100_NEXT_DAY,
+];
+
+const FOUR_ITEMS = [
+  ITEM_1_0115_TO_0230,
+  ITEM_3_0330_TO_0500,
+  ITEM_6_1345_TO_1400,
+  ITEM_7_1430_TO_1700,
+  ITEM_8_1700_TO_1715,
+];
+const FOUR_ITEMS_RELATE_TO_PREV_AND_NEXT_DAY = [
+  ITEM_2300_PREV_DAY_TO_0100,
+  ITEM_1_0115_TO_0230,
+  ITEM_2_0230_TO_0315,
+  ITEM_2300_TO_0100_NEXT_DAY,
+];
+
+const FIVE_ITEMS = [
+  ITEM_5_0915_TO_1345,
+  ITEM_7_1430_TO_1700,
+  ITEM_9_1730_TO_1745,
+  ITEM_10_1800_TO_2245,
+  ITEM_11_2300_TO_2330,
+];
+const ONE_FULL_DAY = [ITEM_12_0000_TO_2359];
+
+// TEST handleClickedTimePoint(clickTimePoint, startOfDisplayDate, endOfDisplayDate, displayItems)
+// Assumption is that no two items in displayItems overlaps
+test("Case 0: Empty day and clickPoint at the startOfDisplayDate", () => {
+  expect(
+    handleClickedTimePoint(
+      startOfDisplayDate,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      EMPTY_DAY
+    )
+  ).toStrictEqual({
+    prevTravelObject: null,
+    freeTimeSlot: { startDate: startOfDisplayDate, endDate: endOfDisplayDate },
+    nextTravelObject: null,
+  });
+});
+
+test("Case 1: Empty day and clickPoint at the endOfDisplayDate", () => {
+  expect(
+    handleClickedTimePoint(
+      endOfDisplayDate,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      EMPTY_DAY
+    )
+  ).toStrictEqual({
+    prevTravelObject: null,
+    freeTimeSlot: { startDate: startOfDisplayDate, endDate: endOfDisplayDate },
+    nextTravelObject: null,
+  });
+});
+
+test("Case 2: Empty day and clickPoint at the middle of displayDate", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1315,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      EMPTY_DAY
+    )
+  ).toStrictEqual({
+    prevTravelObject: null,
+    freeTimeSlot: { startDate: startOfDisplayDate, endDate: endOfDisplayDate },
+    nextTravelObject: null,
+  });
+});
+
+test("Case 3: ClickPoint is in travelObject", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1000,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      ONE_ITEM_IN_THE_MIDDLE
+    )
+  ).toStrictEqual({
+    prevTravelObject: undefined,
+    freeTimeSlot: undefined,
+    nextTravelObject: undefined,
+  });
+});
+
+test("Case 4: One travelobject overflows from the previous day and clickPoint is in the rest of the day", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1000,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      ONE_ITEM_OVERFLOWS_FROM_PREV_DAY
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_2300_PREV_DAY_TO_0100,
+    freeTimeSlot: {startDate: TIMEPOINT_0100, endDate: endOfDisplayDate},
+    nextTravelObject: null,
+  });
+});
+
+test("Case 5: One travelobject overflows to the next day and clickPoint is in the rest of the day", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1000,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      ONE_ITEM_OVERFLOWS_TO_NEXT_DAY
+    )
+  ).toStrictEqual({
+    prevTravelObject: null,
+    freeTimeSlot: {startDate: startOfDisplayDate, endDate: TIMEPOINT_2300},
+    nextTravelObject: ITEM_2300_TO_0100_NEXT_DAY,
+  });
+});
+
+test("Case 6: One travelobject in the middle of displayDate and clickPoint is in the first empty portion of displayDate", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_0500,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      ONE_ITEM_IN_THE_MIDDLE
+    )
+  ).toStrictEqual({
+    prevTravelObject: null,
+    freeTimeSlot: {startDate: startOfDisplayDate, endDate: TIMEPOINT_0915},
+    nextTravelObject: ITEM_5_0915_TO_1345,
+  });
+});
+
+test("Case 7: One travelobject in the middle of displayDate and clickPoint is in the second empty portion of displayDate", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1400,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      ONE_ITEM_IN_THE_MIDDLE
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_5_0915_TO_1345,
+    freeTimeSlot: {startDate: TIMEPOINT_1345, endDate: endOfDisplayDate},
+    nextTravelObject: null,
+  });
+});
+
+test("Case 8: Two items in the middle of the day and a clickPoint in between two items", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1400,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      TWO_ITEMS_NOT_RELATE_TO_PREV_OR_NEXT_DAY
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_2_0230_TO_0315,
+    freeTimeSlot: {startDate: TIMEPOINT_0315, endDate: TIMEPOINT_1700},
+    nextTravelObject: ITEM_8_1700_TO_1715,
+  });
+});
+
+test("Case 9: Two items in the middle of the day and a clickPoint in front of the first item", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_0100,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      TWO_ITEMS_NOT_RELATE_TO_PREV_OR_NEXT_DAY
+    )
+  ).toStrictEqual({
+    prevTravelObject: null,
+    freeTimeSlot: {startDate: startOfDisplayDate, endDate: TIMEPOINT_0230},
+    nextTravelObject: ITEM_2_0230_TO_0315,
+  });
+});
+
+test("Case 10: Two items in the middle of the day and a clickPoint after the second item", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1800,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      TWO_ITEMS_NOT_RELATE_TO_PREV_OR_NEXT_DAY
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_8_1700_TO_1715,
+    freeTimeSlot: {startDate: TIMEPOINT_1715, endDate: endOfDisplayDate},
+    nextTravelObject: null,
+  });
+});
+
+test("Case 11: Two items one of which overflows from the previous day and clickPoint in between two items", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_0230,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      TWO_ITEMS_ONE_FROM_PREV_ANOTHER_MIDDLE
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_2300_PREV_DAY_TO_0100,
+    freeTimeSlot: {startDate: TIMEPOINT_0100, endDate: TIMEPOINT_0915},
+    nextTravelObject: ITEM_5_0915_TO_1345,
+  });
+});
+
+test("Case 12: Two items one of which overflows from the previous day and clickPoint after the second item", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1400,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      TWO_ITEMS_ONE_FROM_PREV_ANOTHER_MIDDLE
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_5_0915_TO_1345,
+    freeTimeSlot: {startDate: TIMEPOINT_1345, endDate: endOfDisplayDate},
+    nextTravelObject: null,
+  });
+});
+
+test("Case 13: Two items one of which overflows from the previous day and clickPoint in the first item", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_0000,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      TWO_ITEMS_ONE_FROM_PREV_ANOTHER_MIDDLE
+    )
+  ).toStrictEqual({
+    prevTravelObject: undefined,
+    freeTimeSlot: undefined,
+    nextTravelObject: undefined,
+  });
+});
+
+test("Case 14: Two items one of which overflows from the previous day and clickPoint in the second item", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_0945,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      TWO_ITEMS_ONE_FROM_PREV_ANOTHER_MIDDLE
+    )
+  ).toStrictEqual({
+    prevTravelObject: undefined,
+    freeTimeSlot: undefined,
+    nextTravelObject: undefined,
+  });
+});
+
+test("Case 15: Three items two of which share the same edge, clickPoint is between of second and third item", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_0645,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      THREE_ITEMS_WITH_2_ITEMS_SAME_EDGE
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_2_0230_TO_0315,
+    freeTimeSlot: {startDate: TIMEPOINT_0315, endDate: TIMEPOINT_0915},
+    nextTravelObject: ITEM_5_0915_TO_1345,
+  });
+});
+
+test("Case 16: Three items with two short items, clickPoint is in middle of two short items", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1718,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      THREE_ITEMS_WITH_2_SHORT_ITEMS
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_8_1700_TO_1715,
+    freeTimeSlot: {startDate: TIMEPOINT_1715, endDate: TIMEPOINT_1730},
+    nextTravelObject: ITEM_9_1730_TO_1745,
+  });
+});
+
+test("Case 17: Three items with two short items, clickPoint is in front of the first short item", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1659,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      THREE_ITEMS_WITH_2_SHORT_ITEMS
+    )
+  ).toStrictEqual({
+    prevTravelObject: null,
+    freeTimeSlot: {startDate: startOfDisplayDate, endDate: TIMEPOINT_1700},
+    nextTravelObject: ITEM_8_1700_TO_1715,
+  });
+});
+
+test("Case 18: Three items with two short items, clickPoint is after the second short item", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1800,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      THREE_ITEMS_WITH_2_SHORT_ITEMS
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_9_1730_TO_1745,
+    freeTimeSlot: {startDate: TIMEPOINT_1745, endDate: TIMEPOINT_2300},
+    nextTravelObject: ITEM_11_2300_TO_2330,
+  });
+});
+
+test("Case 19: Three items, clickPoint is after the third item", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_2331,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      THREE_ITEMS_WITH_2_SHORT_ITEMS
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_11_2300_TO_2330,
+    freeTimeSlot: {startDate: TIMEPOINT_2330, endDate: endOfDisplayDate},
+    nextTravelObject: null,
+  });
+});
+
+test("Case 20: Three items one of which overflows from the previous date, one of the others overflows to the next date, clickPoint is in the between the first and second items", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_0230,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      THREE_ITEMS_RELATE_TO_PREV_AND_NEXT_DAY
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_2300_PREV_DAY_TO_0100,
+    freeTimeSlot: {startDate: TIMEPOINT_0100, endDate: TIMEPOINT_0330},
+    nextTravelObject: ITEM_3_0330_TO_0500,
+  });
+});
+
+
+test("Case 21: Three items one of which overflows from the previous date, one of the others overflows to the next date, clickPoint is in the between the second and third items", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_0645,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      THREE_ITEMS_RELATE_TO_PREV_AND_NEXT_DAY
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_3_0330_TO_0500,
+    freeTimeSlot: {startDate: TIMEPOINT_0500, endDate: TIMEPOINT_2300},
+    nextTravelObject: ITEM_2300_TO_0100_NEXT_DAY,
+  });
+});
+
+test("Case 22: Four items in the middle of displayDate, clickPoint between 1st and 2nd", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_0301,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      FOUR_ITEMS
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_1_0115_TO_0230,
+    freeTimeSlot: {startDate: TIMEPOINT_0230, endDate: TIMEPOINT_0330},
+    nextTravelObject: ITEM_3_0330_TO_0500,
+  });
+});
+
+test("Case 23: Four items in the middle of displayDate, clickPoint between 2nd and 3rd items", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_0645,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      FOUR_ITEMS
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_3_0330_TO_0500,
+    freeTimeSlot: {startDate: TIMEPOINT_0500, endDate: TIMEPOINT_1345},
+    nextTravelObject: ITEM_6_1345_TO_1400,
+  });
+});
+test("Case 24: Four items one of which overflows from previous date and one of the others overflows to the next date", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_0109,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      FOUR_ITEMS_RELATE_TO_PREV_AND_NEXT_DAY
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_2300_PREV_DAY_TO_0100,
+    freeTimeSlot: {startDate: TIMEPOINT_0100, endDate: TIMEPOINT_0115},
+    nextTravelObject: ITEM_1_0115_TO_0230,
+  });
+});
+
+test("Case 25: Five items, Clickpoint is in the last free timeslot of the day", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_2331,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      FIVE_ITEMS
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_11_2300_TO_2330,
+    freeTimeSlot: {startDate: TIMEPOINT_2330, endDate: endOfDisplayDate},
+    nextTravelObject: null,
+  });
+});
+
+test("Case 26: Five items, clickPoint is in between 3rd and 4th item", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_1746,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      FIVE_ITEMS
+    )
+  ).toStrictEqual({
+    prevTravelObject: ITEM_9_1730_TO_1745,
+    freeTimeSlot: {startDate: TIMEPOINT_1745, endDate: TIMEPOINT_1800},
+    nextTravelObject: ITEM_10_1800_TO_2245,
+  });
+});
+
+test("Case 27: One full day, clickPoint is in the item ", () => {
+  expect(
+    handleClickedTimePoint(
+      TIMEPOINT_2331,
+      startOfDisplayDate,
+      endOfDisplayDate,
+      ONE_FULL_DAY
+    )
+  ).toStrictEqual({
+    prevTravelObject: undefined,
+    freeTimeSlot: undefined,
+    nextTravelObject: undefined,
+  });
+});

--- a/step-capstone/src/__tests__/SearchForEmptyTimeslot.test.js
+++ b/step-capstone/src/__tests__/SearchForEmptyTimeslot.test.js
@@ -245,7 +245,7 @@ test("Case 3: ClickPoint is in travelObject", () => {
   });
 });
 
-test("Case 4: One travelobject overflows from the previous day and clickPoint is in the rest of the day", () => {
+test("Case 4: One travelobject overflows from the previous day and clickPoint is in the part of the day after overflow event", () => {
   expect(
     handleClickedTimePoint(
       TIMEPOINT_1000,
@@ -260,7 +260,7 @@ test("Case 4: One travelobject overflows from the previous day and clickPoint is
   });
 });
 
-test("Case 5: One travelobject overflows to the next day and clickPoint is in the rest of the day", () => {
+test("Case 5: One travelobject overflows to the next day and clickPoint is in the part of the day before overflow event", () => {
   expect(
     handleClickedTimePoint(
       TIMEPOINT_1000,

--- a/step-capstone/src/components/Sidebars/HandleClickedTimePoint.js
+++ b/step-capstone/src/components/Sidebars/HandleClickedTimePoint.js
@@ -1,79 +1,27 @@
-export const getEmptySlots = (startOfDisplayDate, endOfDisplayDate, displayItems) => {
-  let emptySlots = [];
+import {twoDateObjectEqual} from '../../scripts/HelperFunctions';
 
-  if (displayItems.length == 0) {
-    emptySlots.push({
-      startDate: startOfDisplayDate,
-      endDate: endOfDisplayDate,
-    });
-    return emptySlots;
-  } else {
-    if (displayItems[0].startDate > startOfDisplayDate) {
-      emptySlots.push({
-        startDate: startOfDisplayDate,
-        endDate: displayItems[0].startDate,
-      });
-    }
-  }
-
-  for (var i = 1; i <= displayItems.length - 1; i++) {
-    let prev = displayItems[i - 1];
-    let cur = displayItems[i];
-
-    emptySlots.push({ startDate: prev.endDate, endDate: cur.startDate });
-  }
-
-  if (displayItems[displayItems.length - 1].endDate < endOfDisplayDate) {
-    emptySlots.push({
-      startDate: displayItems[displayItems.length - 1].endDate,
-      endDate: endOfDisplayDate,
-    });
-  }
-
-  return emptySlots;
-};
-// return whether timeRange from startDate to endDate contains timePoint
-const contains = (interval, timePoint) => {
-  return interval.startDate <= timePoint && timePoint <= interval.endDate;
-};
-
-//Receives a list of non-overlapping intervals and 2 timepoints,
-// return a timePoint that belongs to interval [timePointStart, timePointEnd] and an interval from the give list.
-const searchForOverlappingPoint = (intervals,timePointStart,timePointEnd) => {
-  if (intervals === undefined || intervals.length == 0) {
-    return timePointStart;
-  }
-  let low = 0;
-  let high = intervals.length - 1;
-
-  while (low <= high) {
-    let centerIndex = Math.floor((low + high) / 2);
-    let centerInterval = intervals[centerIndex];
-    if (contains(centerInterval, timePointStart)) {
-      return timePointStart;
-    } else if (contains(centerInterval, timePointEnd)) {
-      return timePointEnd;
-    } else if (timePointEnd < centerInterval.startDate) {
-      high = centerIndex - 1;
-    } else {
-      low = centerIndex + 1;
-    }
-  }
-
-  return null;
-};
-
-//Receives a list of travelobjects and returns the travelobjects that is in front and after the timePoint
-//fakeStart    |----A------|  timePoint  |--B--| |-C--|  |-------D------|         fakeEnd
-//return {A, {startDate: B}
-//if timePoint is in a travelobjects, return undefined for both A and B
-//if either A or B doesn't exist, return null for that travelobject
-const searchForPrevAndNextTravelObject = (startOfDisplayDate, endOfDisplayDate, displayItems, timePoint) => {
+// Receives a list of travelobjects and returns the travelobjects
+// that is in front and after the timePoint
+//   |----A------|  timePoint  |--B--| |-C--|  |-------D------|
+// Return { prevTravelObject: A, nextTravelObject: B }
+// If timePoint is in a travelobjects, return { prevTravelObject: undefined, nextTravelObject: undefined }
+// If either A or B doesn't exist, return null for that prev[next]TravelObject
+const searchForPrevAndNextTravelObject = (
+  startOfDisplayDate,
+  endOfDisplayDate,
+  displayItems,
+  timePoint
+) => {
   if (displayItems.length == 0) {
     return { prevTravelObject: null, nextTravelObject: null };
   }
 
+  // Create fake startOfDisplayDate and endOfDisplayDate travelObjects
+  // to feed in searchForPrevAndNextTravelObjectHelperFunction
+
   let intervals = [];
+  // If displayItems already includes a travelObject which starts from the previous date,
+  // we don't create the fake start
   if (displayItems[0].startDate > startOfDisplayDate) {
     let fakeStart = {
       startDate: startOfDisplayDate,
@@ -84,15 +32,25 @@ const searchForPrevAndNextTravelObject = (startOfDisplayDate, endOfDisplayDate, 
 
   intervals = intervals.concat(displayItems);
 
+  // If displayItems already includes a travelObject which ends at the next date,
+  // we don't create the fake end
   if (displayItems[displayItems.length - 1].endDate < endOfDisplayDate) {
     let fakeEnd = { startDate: endOfDisplayDate, endDate: endOfDisplayDate };
     intervals.push(fakeEnd);
   }
 
-  return searchForPrevAndNextTravelObjectHelperFunction(startOfDisplayDate, endOfDisplayDate, intervals, timePoint);
+  return searchForPrevAndNextTravelObjectHelperFunction(
+    startOfDisplayDate,
+    intervals,
+    timePoint
+  );
 };
 
-function searchForPrevAndNextTravelObjectHelperFunction(startOfDisplayDate, endOfDisplayDate, intervals, timePoint) {
+function searchForPrevAndNextTravelObjectHelperFunction(
+  startOfDisplayDate,
+  intervals,
+  timePoint
+) {
   let low = 0;
   let high = intervals.length - 1;
   let prevTravelObject = undefined;
@@ -108,8 +66,9 @@ function searchForPrevAndNextTravelObjectHelperFunction(startOfDisplayDate, endO
       centerInterval.startDate <= timePoint &&
       timePoint <= centerInterval.startDate
     ) {
+      // Check that centerInterval is not fake start or fake end
       if (centerInterval.id !== undefined) {
-        if (centerInterval.startDate === startOfDisplayDate) {
+        if (twoDateObjectEqual(centerInterval.startDate, startOfDisplayDate)) {
           low = centerIndex + 1;
         } else {
           high = centerIndex - 1;
@@ -145,32 +104,36 @@ function searchForPrevAndNextTravelObjectHelperFunction(startOfDisplayDate, endO
 }
 
 //Return the empty timeRange that users click into by performing binary search on emptySlots array
-export const handleClickedTimePoint = (idV, startOfDisplayDate, endOfDisplayDate, displayItems, emptySlots) => {
-  let timePointStart = new Date(
-    startOfDisplayDate.getFullYear(),
-    startOfDisplayDate.getMonth(),
-    startOfDisplayDate.getDate(),
-    idV.slice(0, 2),
-    idV.slice(3),
-    0
+export const handleClickedTimePoint = (
+  clickTimePoint,
+  startOfDisplayDate,
+  endOfDisplayDate,
+  displayItems
+) => {
+  let prevAndNextTravelObject = searchForPrevAndNextTravelObject(
+    startOfDisplayDate,
+    endOfDisplayDate,
+    displayItems,
+    clickTimePoint
   );
 
-  let timePointEnd = new Date(timePointStart);
-  timePointEnd.setTime(timePointEnd.getTime() + 30 * 60000);
-  let overlappingPoint = searchForOverlappingPoint(emptySlots,timePointStart,timePointEnd);
-  if (overlappingPoint === null) {
-    return { prevTravelObject: undefined, freeTimeSlot: undefined, nextTravelObject: undefined };
-  }
-  let prevAndNextTravelObject = searchForPrevAndNextTravelObject(startOfDisplayDate, endOfDisplayDate, displayItems, overlappingPoint)
-  
   if (prevAndNextTravelObject.prevTravelObject === undefined) {
     prevAndNextTravelObject.freeTimeSlot = undefined;
     return prevAndNextTravelObject;
   }
 
-  let prevTravelObjectEnd = (prevAndNextTravelObject.prevTravelObject !== null)? prevAndNextTravelObject.prevTravelObject.endDate : startOfDisplayDate;
-  let nextTravelObjectStart = (prevAndNextTravelObject.nextTravelObject !== null)? prevAndNextTravelObject.nextTravelObject.startDate : endOfDisplayDate;
-  let freeTimeSlot = {startDate: prevTravelObjectEnd, endDate: nextTravelObjectStart}
+  let prevTravelObjectEnd =
+    prevAndNextTravelObject.prevTravelObject !== null
+      ? prevAndNextTravelObject.prevTravelObject.endDate
+      : startOfDisplayDate;
+  let nextTravelObjectStart =
+    prevAndNextTravelObject.nextTravelObject !== null
+      ? prevAndNextTravelObject.nextTravelObject.startDate
+      : endOfDisplayDate;
+  let freeTimeSlot = {
+    startDate: prevTravelObjectEnd,
+    endDate: nextTravelObjectStart,
+  };
 
   prevAndNextTravelObject.freeTimeSlot = freeTimeSlot;
   return prevAndNextTravelObject;

--- a/step-capstone/src/components/Sidebars/OneHourInterval.js
+++ b/step-capstone/src/components/Sidebars/OneHourInterval.js
@@ -4,12 +4,15 @@ import InsertObjectPopover from "./InsertObjectPopover";
 import DraggableFinalized from "../TravelObjects/DraggableFinalized";
 import { ItemTypes, moveTravelObject } from "../../scripts/DragTravelObject";
 import { useDrop } from "react-dnd";
+import {
+  displayHeightOfADiv,
+  padding,
+  minPerDiv,
+  millisecondsPerMin,
+} from "../../scripts/Constants";
 
 export default function OneHourInterval(props) {
   const [slots, setSlots] = useState(null);
-  const displayHeightOfADiv = 45.47;
-  const padding = 22.0;
-  const minPerDiv = 30.0;
   const [anchorEl, setAnchorEl] = React.useState(null);
 
   const [{ isOver, canDrop }, drop] = useDrop({
@@ -21,9 +24,33 @@ export default function OneHourInterval(props) {
     }),
   });
 
+// Given a id of a div and an mouse click event
+// Return the exact timePoint of the click
+  const getExactClickTimePoint = (idV, event) => {
+    // Calculate how many minutes the click is away from the top of the div
+    const div = window.document.getElementById(idV);
+    const rect = div.getBoundingClientRect();
+    const y = event.clientY - rect.top;
+    const y2min = Math.floor((y / displayHeightOfADiv) * minPerDiv);
+
+    // Convert the mouse click into a timepoint in displayDate
+    idV = idV.length < 5 ? "0" + idV : idV;
+    var clickTimePoint = new Date(
+      props.displayDate.getFullYear(),
+      props.displayDate.getMonth(),
+      props.displayDate.getDate(),
+      Number(idV.slice(0, 2)),
+      Number(idV.slice(3)),
+      0
+    );
+
+    clickTimePoint.setTime(clickTimePoint.getTime() + y2min * millisecondsPerMin);
+    return clickTimePoint;
+  };
   const handleOnClickInterval = (idV, event) => {
     if (event.target.className === "Interval") {
-      let data = props.onClickInterval(idV);
+      var clickTimePoint = getExactClickTimePoint(idV, event);
+      let data = props.onClickInterval(clickTimePoint);
       if (data.freeTimeSlot !== undefined) {
         setSlots(data);
         setAnchorEl(event.currentTarget);

--- a/step-capstone/src/components/Sidebars/OneHourInterval.js
+++ b/step-capstone/src/components/Sidebars/OneHourInterval.js
@@ -24,7 +24,7 @@ export default function OneHourInterval(props) {
     }),
   });
 
-// Given a id of a div and an mouse click event
+// Given an id of a div and an mouse click event
 // Return the exact timePoint of the click
   const getExactClickTimePoint = (idV, event) => {
     // Calculate how many minutes the click is away from the top of the div

--- a/step-capstone/src/components/Sidebars/TimeLine.js
+++ b/step-capstone/src/components/Sidebars/TimeLine.js
@@ -69,15 +69,12 @@ export default class TimeLine extends React.Component {
     }
   }
 
-  handleOnClickInterval(idV) {
-    idV = idV.length < 5 ? "0" + idV : idV;
-
+  handleOnClickInterval(clickTimePoint) {
     return handleClickedTimePoint(
-      idV,
+      clickTimePoint,
       this.startOfDisplayDate,
       this.endOfDisplayDate,
       this.displayItemsExcludeHotel,
-      this.emptySlots
     );
   }
 
@@ -87,7 +84,6 @@ export default class TimeLine extends React.Component {
     if (this.props.displayDate !== undefined) {
       this.startOfDisplayDate = this.date2Items = new Map();
       this.displayItems = [];
-      this.emptySlots = [];
       this.startOfDisplayDate = new Date(
         this.props.displayDate.getFullYear(),
         this.props.displayDate.getMonth(),
@@ -118,8 +114,6 @@ export default class TimeLine extends React.Component {
         this.props.displayDate.toDateString()
       );
       this.displayItemsExcludeHotel = this.displayItems.filter((item) => item.type !== "hotel");
-
-      this.emptySlots = getEmptySlots(this.startOfDisplayDate, this.endOfDisplayDate, this.displayItemsExcludeHotel)
 
       var nextItemIndex = 0;
       var hotel = null; // flags hotel until finds right place in timeline

--- a/step-capstone/src/components/TravelObjects/DraggableFinalized.js
+++ b/step-capstone/src/components/TravelObjects/DraggableFinalized.js
@@ -45,7 +45,7 @@ export default function DraggableFinalized(props) {
       style={{
         position: "absolute",
         width: "100%",
-        height: "30px",
+        height: "1px",
         top: props.styleConfig.top,
         opacity,
         zIndex: props.styleConfig.zIndex,

--- a/step-capstone/src/scripts/Constants.js
+++ b/step-capstone/src/scripts/Constants.js
@@ -1,0 +1,4 @@
+export const displayHeightOfADiv = 45.47;
+export const padding = 22.0;
+export const minPerDiv = 30.0;
+export const millisecondsPerMin = 60000;

--- a/step-capstone/src/scripts/HelperFunctions.js
+++ b/step-capstone/src/scripts/HelperFunctions.js
@@ -18,6 +18,7 @@ export const sameDate = (timeA, timeB) => {
 
 // Given 2 Date objects, return true if they are the same; false otherwise
 // Ignore milliseconds
+// This function is added since === is not consistent in comparing two DateTime object
 export const twoDateObjectEqual = (timeA, timeB) => {
   return (timeA.getDate() === timeB.getDate() && 
         timeA.getMonth() === timeB.getMonth() && 

--- a/step-capstone/src/scripts/HelperFunctions.js
+++ b/step-capstone/src/scripts/HelperFunctions.js
@@ -16,6 +16,16 @@ export const sameDate = (timeA, timeB) => {
   return (timeA.getDate() === timeB.getDate() && timeA.getMonth() === timeB.getMonth() && timeA.getFullYear() === timeB.getFullYear());
 }
 
+// Given 2 Date objects, return true if they are the same; false otherwise
+// Ignore milliseconds
+export const twoDateObjectEqual = (timeA, timeB) => {
+  return (timeA.getDate() === timeB.getDate() && 
+        timeA.getMonth() === timeB.getMonth() && 
+        timeA.getFullYear() === timeB.getFullYear() &&
+        timeA.getHours() === timeB.getHours() &&
+        timeA.getMinutes() === timeB.getMinutes());
+}
+
 export const isValid = function (date) {
   // An invalid date object returns NaN for getTime() and NaN is the only
   // object not strictly equal to itself.


### PR DESCRIPTION
1) On writing test for `handle click in Timeline` feature, I realize the current code can't handle cases where one 30-min div has a small TravelObject in the middle of the div.
For example:
![image](https://user-images.githubusercontent.com/42331170/89042859-9d984f00-d315-11ea-9d2d-dc1d82fbbede.png)


If user clicks in part A or part B of the div, the current code doesn't know which part is clicked and just return a random one A or B.
Before, we thought that using a function which looks for overlapping between the clicked div and a array of free Timeslot would help, but it only helps in cases like this (meaning overlapping function only helps deal with cases where a 30-min div has only one free timeslot):

![image](https://user-images.githubusercontent.com/42331170/89042872-a4bf5d00-d315-11ea-8b07-ff125916a3d3.png)


Thus, this PR:
1) adds function to calculate the exact timePoint the user clicks into instead. (See `OneHourInterval`)
2) removes the `getFreeTimeSlot` and `searchForOverlappingPoint` function
3) adds unit tests to test the handleClickedTimePoint function. (See `HandleClickedTimePoint`)

(1) and (2) help reduce the time complexity of the `handle click in Timeline` feature from O(n) to O(logn) (where n is the number of displayItems), since we no longer need to iterate through displayItems to get the free timeslots anymore.